### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/yarlson/lnk/security/code-scanning/4](https://github.com/yarlson/lnk/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root of the workflow to define the minimal permissions required for all jobs. Since the workflow primarily involves testing, linting, building, and uploading coverage, we will start with `contents: read` and add any additional permissions required for specific steps. For example, the `Upload coverage to Codecov` step might require `contents: read` to access the coverage file, and the `Test GoReleaser` step might require additional permissions depending on its functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
