### PR TITLE
Control CLI output and improve command discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ desktop.ini
 # GoReleaser artifacts
 goreleaser/
 /target/
+.snap/

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ lnk add --dry-run ~/.tmux.conf            # preview first
 ```bash
 lnk status                                # what changed
 lnk diff                                  # uncommitted changes
+lnk diff --quiet                          # exit code only, no output
+lnk diff --colors always                  # force color output (useful in scripts/redirects)
 lnk push "updated vim config"             # commit & push
 lnk pull                                  # pull & restore symlinks
 lnk pull --host work                      # pull host-specific config
@@ -125,6 +127,16 @@ That's it. Bootstrap runs automatically, symlinks get restored, you're working.
 | `pull [--host H]`                                  | Pull and restore symlinks                   |
 | `doctor [--host H] [--dry-run]`                    | Find and fix repo health issues             |
 | `bootstrap`                                        | Run bootstrap.sh from repo                  |
+
+## Global Options
+
+Available with all commands:
+
+| Option                       | Default | What it does                                                  |
+| ---------------------------- | ------- | ------------------------------------------------------------- |
+| `--colors auto\|always\|never` | `auto`    | Control color output (auto: based on terminal detection)     |
+| `--emoji`, `--no-emoji`        | enabled | Enable/disable emoji in output                               |
+| `--quiet` or `-q`              | off     | Suppress all output (useful in scripts, exit code only)       |
 
 ## Why lnk over alternatives
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ lnk add --dry-run ~/.tmux.conf            # preview first
 ### Sync
 
 ```bash
-lnk status                                # what changed
+lnk status                                # what changed (works even without remote)
 lnk diff                                  # uncommitted changes
 lnk diff --quiet                          # exit code only, no output
 lnk diff --colors always                  # force color output (useful in scripts/redirects)
@@ -72,12 +72,16 @@ lnk pull                                  # pull & restore symlinks
 lnk pull --host work                      # pull host-specific config
 ```
 
+`status` works without a remote configured — it shows local state (dirty/clean, unpushed commits) and guides you to add a remote.
+
 ### Remove
 
 ```bash
 lnk rm ~/.vimrc                           # moves file back, removes symlink
-lnk rm --force ~/.bashrc                  # clean up if symlink already gone
+lnk rm --force ~/.bashrc                  # tracking cleanup only (no file restoration)
 ```
+
+`--force` is for cleanup when the symlink is already gone (e.g., you deleted it manually). It removes the entry from `.lnk` and the stored file from the repo, but does **not** restore anything to your home directory. Use normal `lnk rm` for a full removal with restoration.
 
 ### List
 
@@ -93,6 +97,8 @@ lnk list --all                            # everything
 lnk doctor --dry-run                      # preview issues
 lnk doctor                                # fix broken symlinks & stale entries
 ```
+
+When restoring symlinks, if a real file exists at the target location (not a symlink), it will be renamed to `<path>.lnk-backup` to preserve your data before the symlink is created. Check for `.lnk-backup` files after running `doctor` or `pull` if you expect them.
 
 ### Bootstrap
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Git-native dotfiles manager. No config files, no templates, no ceremony.**
 
-Track dotfiles across machines with one command. Lnk moves files into a Git repo (`~/.config/lnk`), symlinks them back, and stays out of your way.
+Track dotfiles across machines with one command. Lnk moves files into a Git repo (defaults to `~/.config/lnk`; override with `LNK_HOME` or `XDG_CONFIG_HOME`), symlinks them back, and stays out of your way.
 
 ```bash
 lnk init -r git@github.com:you/dotfiles.git   # clone & bootstrap

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -51,11 +51,11 @@ changes to your system - perfect for verification before bulk operations.`,
 					w.Writeln(Message{Text: fmt.Sprintf("Would add %d files:", len(files)), Emoji: "🔍", Bold: true})
 				}
 
-				// List files that would be added
+				// List files using home-relative paths so duplicate basenames remain distinguishable.
+				// Dry-run is a preview for verification, so show all files.
 				for _, file := range files {
-					basename := filepath.Base(file)
 					w.WriteString("   ").
-						Writeln(Message{Text: basename, Emoji: "📄"})
+						Writeln(Message{Text: displaySourcePath(file), Emoji: "📄"})
 				}
 
 				w.WritelnString("").
@@ -72,17 +72,22 @@ changes to your system - perfect for verification before bulk operations.`,
 					return err
 				}
 
-				// Create progress callback for CLI display
-				progressCallback := func(current, total int, currentFile string) {
-					w.WriteString(fmt.Sprintf("\r⏳ Processing %d/%d: %s", current, total, currentFile))
+				// Only show carriage-return progress when output is a terminal;
+				// in piped/non-TTY contexts the redraw becomes noise.
+				var progressCallback lnk.ProgressCallback
+				if w.IsTerminal() {
+					progressCallback = func(current, total int, currentFile string) {
+						w.WriteString(fmt.Sprintf("\r⏳ Processing %d/%d: %s", current, total, currentFile))
+					}
 				}
 
 				if err := l.AddRecursiveWithProgress(args, progressCallback); err != nil {
 					return err
 				}
 
-				// Clear progress line and show completion
-				w.WriteString("\r")
+				if w.IsTerminal() {
+					w.WriteString("\r")
+				}
 
 				// Store processed file count for display
 				args = previewFiles // Replace args with actual files for display
@@ -112,21 +117,20 @@ changes to your system - perfect for verification before bulk operations.`,
 
 				// Show some of the files that were added (limit to first few for readability)
 				filesToShow := len(args)
-				if filesToShow > 5 {
-					filesToShow = 5
+				if filesToShow > displayLimit {
+					filesToShow = displayLimit
 				}
 
 				for i := 0; i < filesToShow; i++ {
-					basename := filepath.Base(args[i])
 					w.WriteString("   ").
-						Write(Link(basename)).
+						Write(Link(displaySourcePath(args[i]))).
 						WriteString(" → ").
 						Writeln(Colored(lnk.FormatManagedPath(host, args[i]), ColorCyan))
 				}
 
-				if len(args) > 5 {
+				if len(args) > displayLimit {
 					w.WriteString("   ").
-						Writeln(Colored(fmt.Sprintf("... and %d more files", len(args)-5), ColorGray))
+						Writeln(Colored(fmt.Sprintf("... and %d more files", len(args)-displayLimit), ColorGray))
 				}
 			} else if len(args) == 1 {
 				// Single file - maintain existing output format for backward compatibility
@@ -149,13 +153,21 @@ changes to your system - perfect for verification before bulk operations.`,
 					w.Writeln(Sparkles(fmt.Sprintf("Added %d items to lnk", len(args))))
 				}
 
-				// List each added file
-				for _, filePath := range args {
-					basename := filepath.Base(filePath)
+				// List each added file using home-relative source paths so same-basename
+				// files in different directories stay distinguishable. Truncate large batches.
+				filesToShow := len(args)
+				if filesToShow > displayLimit {
+					filesToShow = displayLimit
+				}
+				for i := 0; i < filesToShow; i++ {
 					w.WriteString("   ").
-						Write(Link(basename)).
+						Write(Link(displaySourcePath(args[i]))).
 						WriteString(" → ").
-						Writeln(Colored(lnk.FormatManagedPath(host, filePath), ColorCyan))
+						Writeln(Colored(lnk.FormatManagedPath(host, args[i]), ColorCyan))
+				}
+				if len(args) > displayLimit {
+					w.WriteString("   ").
+						Writeln(Colored(fmt.Sprintf("... and %d more files", len(args)-displayLimit), ColorGray))
 				}
 			}
 
@@ -172,4 +184,21 @@ changes to your system - perfect for verification before bulk operations.`,
 	cmd.Flags().BoolP("recursive", "r", false, "Add directory contents individually instead of the directory as a whole")
 	cmd.Flags().BoolP("dry-run", "n", false, "Show what would be added without making changes")
 	return cmd
+}
+
+// displayLimit caps the number of per-file entries shown in batch summaries
+// before collapsing the remainder into "... and N more files".
+const displayLimit = 5
+
+// displaySourcePath renders a path (relative or absolute) as a home-relative
+// (~/foo) display string, falling back to the original input on resolution
+// failure. Used so duplicate basenames in different directories remain
+// distinguishable in preview and batch output. The Abs call is idempotent
+// for paths already absolute (from PreviewAdd) and normalizes relative paths.
+func displaySourcePath(p string) string {
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return p
+	}
+	return lnk.DisplayPath(abs)
 }

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -34,12 +34,12 @@ changes to your system - perfect for verification before bulk operations.`,
 			host, _ := cmd.Flags().GetString("host")
 			recursive, _ := cmd.Flags().GetBool("recursive")
 			dryRun, _ := cmd.Flags().GetBool("dry-run")
-			lnk := lnk.NewLnk(lnk.WithHost(host))
+			l := lnk.NewLnk(lnk.WithHost(host))
 			w := GetWriter(cmd)
 
 			// Handle dry-run mode
 			if dryRun {
-				files, err := lnk.PreviewAdd(args, recursive)
+				files, err := l.PreviewAdd(args, recursive)
 				if err != nil {
 					return err
 				}
@@ -67,7 +67,7 @@ changes to your system - perfect for verification before bulk operations.`,
 			// Handle recursive mode
 			if recursive {
 				// Get preview to count files first for better output
-				previewFiles, err := lnk.PreviewAdd(args, recursive)
+				previewFiles, err := l.PreviewAdd(args, recursive)
 				if err != nil {
 					return err
 				}
@@ -77,7 +77,7 @@ changes to your system - perfect for verification before bulk operations.`,
 					w.WriteString(fmt.Sprintf("\r⏳ Processing %d/%d: %s", current, total, currentFile))
 				}
 
-				if err := lnk.AddRecursiveWithProgress(args, progressCallback); err != nil {
+				if err := l.AddRecursiveWithProgress(args, progressCallback); err != nil {
 					return err
 				}
 
@@ -90,12 +90,12 @@ changes to your system - perfect for verification before bulk operations.`,
 				// Use appropriate method based on number of files
 				if len(args) == 1 {
 					// Single file - use existing Add method for backward compatibility
-					if err := lnk.Add(args[0]); err != nil {
+					if err := l.Add(args[0]); err != nil {
 						return err
 					}
 				} else {
 					// Multiple files - use AddMultiple for atomic operation
-					if err := lnk.AddMultiple(args); err != nil {
+					if err := l.AddMultiple(args); err != nil {
 						return err
 					}
 				}
@@ -118,17 +118,10 @@ changes to your system - perfect for verification before bulk operations.`,
 
 				for i := 0; i < filesToShow; i++ {
 					basename := filepath.Base(args[i])
-					if host != "" {
-						w.WriteString("   ").
-							Write(Link(basename)).
-							WriteString(" → ").
-							Writeln(Colored(fmt.Sprintf("~/.config/lnk/%s.lnk/...", host), ColorCyan))
-					} else {
-						w.WriteString("   ").
-							Write(Link(basename)).
-							WriteString(" → ").
-							Writeln(Colored("~/.config/lnk/...", ColorCyan))
-					}
+					w.WriteString("   ").
+						Write(Link(basename)).
+						WriteString(" → ").
+						Writeln(Colored(lnk.FormatManagedPath(host, args[i]), ColorCyan))
 				}
 
 				if len(args) > 5 {
@@ -141,17 +134,13 @@ changes to your system - perfect for verification before bulk operations.`,
 				basename := filepath.Base(filePath)
 				if host != "" {
 					w.Writeln(Sparkles(fmt.Sprintf("Added %s to lnk (host: %s)", basename, host)))
-					w.WriteString("   ").
-						Write(Link(filePath)).
-						WriteString(" → ").
-						Writeln(Colored(fmt.Sprintf("~/.config/lnk/%s.lnk/%s", host, filePath), ColorCyan))
 				} else {
 					w.Writeln(Sparkles(fmt.Sprintf("Added %s to lnk", basename)))
-					w.WriteString("   ").
-						Write(Link(filePath)).
-						WriteString(" → ").
-						Writeln(Colored(fmt.Sprintf("~/.config/lnk/%s", filePath), ColorCyan))
 				}
+				w.WriteString("   ").
+					Write(Link(filePath)).
+					WriteString(" → ").
+					Writeln(Colored(lnk.FormatManagedPath(host, filePath), ColorCyan))
 			} else {
 				// Multiple files - show summary
 				if host != "" {
@@ -163,17 +152,10 @@ changes to your system - perfect for verification before bulk operations.`,
 				// List each added file
 				for _, filePath := range args {
 					basename := filepath.Base(filePath)
-					if host != "" {
-						w.WriteString("   ").
-							Write(Link(basename)).
-							WriteString(" → ").
-							Writeln(Colored(fmt.Sprintf("~/.config/lnk/%s.lnk/...", host), ColorCyan))
-					} else {
-						w.WriteString("   ").
-							Write(Link(basename)).
-							WriteString(" → ").
-							Writeln(Colored("~/.config/lnk/...", ColorCyan))
-					}
+					w.WriteString("   ").
+						Write(Link(basename)).
+						WriteString(" → ").
+						Writeln(Colored(lnk.FormatManagedPath(host, filePath), ColorCyan))
 				}
 			}
 

--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -1,12 +1,23 @@
 package cmd
 
 import (
+	"io"
 	"os"
 
 	"github.com/spf13/cobra"
 
 	"github.com/yarlson/lnk/internal/lnk"
 )
+
+// bootstrapWriters returns the stdout/stderr targets to hand to the
+// bootstrap script: the cobra command's writers in normal mode, or
+// io.Discard in both slots when --quiet is set.
+func bootstrapWriters(cmd *cobra.Command, w *Writer) (io.Writer, io.Writer) {
+	if w.Quiet() {
+		return io.Discard, io.Discard
+	}
+	return cmd.OutOrStdout(), cmd.ErrOrStderr()
+}
 
 func newBootstrapCmd() *cobra.Command {
 	return &cobra.Command{
@@ -49,7 +60,8 @@ func newBootstrapCmd() *cobra.Command {
 				return err
 			}
 
-			if err := lnk.RunBootstrapScript(scriptPath, os.Stdout, os.Stderr, os.Stdin); err != nil {
+			scriptOut, scriptErr := bootstrapWriters(cmd, w)
+			if err := lnk.RunBootstrapScript(scriptPath, scriptOut, scriptErr, os.Stdin); err != nil {
 				return err
 			}
 

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -17,9 +17,10 @@ func newDiffCmd() *cobra.Command {
 			l := lnk.NewLnk()
 			w := GetWriter(cmd)
 
-			// In quiet mode, skip computing and displaying diff output entirely.
+			// In quiet mode, avoid materializing the patch — only validate the
+			// repo and probe for changes via `git diff --quiet`.
 			if w.Quiet() {
-				_, err := l.Diff(false)
+				_, err := l.HasDiff()
 				return err
 			}
 

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -1,10 +1,17 @@
 package cmd
 
 import (
+	"errors"
+
 	"github.com/spf13/cobra"
 
 	"github.com/yarlson/lnk/internal/lnk"
 )
+
+// errDiffHasChanges is returned by `lnk diff --quiet` when the repo has
+// uncommitted changes. It exists only to drive a non-zero exit code;
+// quiet mode suppresses error display, so callers see only the exit code.
+var errDiffHasChanges = errors.New("repository has uncommitted changes")
 
 func newDiffCmd() *cobra.Command {
 	return &cobra.Command{
@@ -17,11 +24,18 @@ func newDiffCmd() *cobra.Command {
 			l := lnk.NewLnk()
 			w := GetWriter(cmd)
 
-			// In quiet mode, avoid materializing the patch — only validate the
-			// repo and probe for changes via `git diff --quiet`.
+			// In quiet mode, avoid materializing the patch — probe for changes
+			// via `git diff --quiet` and signal dirty state through the exit
+			// code (errDiffHasChanges → exit 1).
 			if w.Quiet() {
-				_, err := l.HasDiff()
-				return err
+				dirty, err := l.HasDiff()
+				if err != nil {
+					return err
+				}
+				if dirty {
+					return errDiffHasChanges
+				}
+				return nil
 			}
 
 			output, err := l.Diff(w.Colors())

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -10,16 +10,16 @@ func newDiffCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:           "diff",
 		Short:         "📝 Show uncommitted changes in the repository",
-		Long:          "Displays a diff of uncommitted changes in the lnk repository, equivalent to running git diff in ~/.config/lnk.",
+		Long:          "Displays a diff of uncommitted changes in the lnk repository, equivalent to running git diff inside the lnk repo.",
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			lnk := lnk.NewLnk()
+			l := lnk.NewLnk()
 
 			// Determine color mode based on terminal detection
 			useColor := isTerminal()
 
-			output, err := lnk.Diff(useColor)
+			output, err := l.Diff(useColor)
 			if err != nil {
 				return err
 			}

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -15,16 +15,18 @@ func newDiffCmd() *cobra.Command {
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			l := lnk.NewLnk()
+			w := GetWriter(cmd)
 
-			// Determine color mode based on terminal detection
-			useColor := isTerminal()
-
-			output, err := l.Diff(useColor)
-			if err != nil {
+			// In quiet mode, skip computing and displaying diff output entirely.
+			if w.Quiet() {
+				_, err := l.Diff(false)
 				return err
 			}
 
-			w := GetWriter(cmd)
+			output, err := l.Diff(w.Colors())
+			if err != nil {
+				return err
+			}
 
 			if output == "" {
 				w.Writeln(Success("No uncommitted changes")).
@@ -33,9 +35,8 @@ func newDiffCmd() *cobra.Command {
 				return w.Err()
 			}
 
-			// Write diff output directly to command's stdout
-			cmd.Print(output)
-			return nil
+			w.WriteString(output)
+			return w.Err()
 		},
 	}
 }

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -115,6 +115,8 @@ Use --dry-run to preview what would be fixed without making changes.`,
 				}
 			}
 
+			writeBackupNotice(w, result.BackedUp)
+
 			// Show removed invalid entries
 			if len(result.InvalidEntries) > 0 {
 				w.WritelnString("")

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -79,7 +79,8 @@ func newInitCmd() *cobra.Command {
 							return err
 						}
 
-						if err := l.RunBootstrapScript(scriptPath, os.Stdout, os.Stderr, os.Stdin); err != nil {
+						scriptOut, scriptErr := bootstrapWriters(cmd, w)
+					if err := l.RunBootstrapScript(scriptPath, scriptOut, scriptErr, os.Stdin); err != nil {
 							w.WritelnString("").
 								Writeln(Warning("Bootstrap script failed, but repository was initialized successfully")).
 								WriteString("   ").

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -80,7 +80,7 @@ func newInitCmd() *cobra.Command {
 						}
 
 						scriptOut, scriptErr := bootstrapWriters(cmd, w)
-					if err := l.RunBootstrapScript(scriptPath, scriptOut, scriptErr, os.Stdin); err != nil {
+						if err := l.RunBootstrapScript(scriptPath, scriptOut, scriptErr, os.Stdin); err != nil {
 							w.WritelnString("").
 								Writeln(Warning("Bootstrap script failed, but repository was initialized successfully")).
 								WriteString("   ").

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -104,12 +105,26 @@ func newInitCmd() *cobra.Command {
 					}
 				}
 
+				hosts, err := findHostConfigs()
+				if err != nil {
+					// best-effort: if host enumeration fails, skip per-host hints
+					// (init already succeeded, this is non-critical)
+					hosts = nil
+				}
+
 				w.WritelnString("").
 					Writeln(Info("Next steps:")).
 					WriteString("   • Run ").
 					Write(Bold("lnk pull")).
-					Writeln(Plain(" to restore symlinks")).
-					WriteString("   • Use ").
+					Writeln(Plain(" to restore symlinks"))
+
+				for _, host := range hosts {
+					w.WriteString("   • Run ").
+						Write(Bold(fmt.Sprintf("lnk pull --host %s", host))).
+						Writeln(Plain(fmt.Sprintf(" to restore the %s configuration", host)))
+				}
+
+				w.WriteString("   • Use ").
 					Write(Bold("lnk add <file>")).
 					Writeln(Plain(" to manage new files"))
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -186,12 +186,17 @@ func listAllConfigs(cmd *cobra.Command) error {
 					Writeln(Link(item))
 			}
 		}
+
+		w.WriteString("   ").
+			Write(Info("Run ")).
+			Write(Bold(fmt.Sprintf("lnk pull --host %s", host))).
+			WritelnString(" to restore these symlinks")
 	}
 
 	w.WritelnString("").
 		Write(Info("Use ")).
 		Write(Bold("lnk list --host <hostname>")).
-		WritelnString(" to see specific host configuration")
+		WritelnString(" to see a single host configuration")
 	return w.Err()
 }
 

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -202,6 +202,16 @@ func isTerminal() bool {
 	return (fileInfo.Mode() & os.ModeCharDevice) != 0
 }
 
+// Colors reports whether color output is enabled for this writer.
+func (w *Writer) Colors() bool {
+	return w.config.Colors
+}
+
+// Quiet reports whether quiet mode is enabled for this writer.
+func (w *Writer) Quiet() bool {
+	return w.config.Quiet
+}
+
 // IsTerminal reports whether the writer's underlying output is a terminal.
 func (w *Writer) IsTerminal() bool {
 	f, ok := w.out.(*os.File)

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -202,6 +202,19 @@ func isTerminal() bool {
 	return (fileInfo.Mode() & os.ModeCharDevice) != 0
 }
 
+// IsTerminal reports whether the writer's underlying output is a terminal.
+func (w *Writer) IsTerminal() bool {
+	f, ok := w.out.(*os.File)
+	if !ok {
+		return false
+	}
+	info, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return (info.Mode() & os.ModeCharDevice) != 0
+}
+
 // autoDetectConfig performs one-time auto-detection if not explicitly configured
 func autoDetectConfig() {
 	if !autoDetected {

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -20,21 +20,21 @@ func newPullCmd() *cobra.Command {
 			lnk := lnk.NewLnk(lnk.WithHost(host))
 			w := GetWriter(cmd)
 
-			restored, err := lnk.Pull()
+			result, err := lnk.Pull()
 			if err != nil {
 				return err
 			}
 
-			if len(restored) > 0 {
-				var successMsg string
-				if host != "" {
-					successMsg = fmt.Sprintf("Successfully pulled changes (host: %s)", host)
-				} else {
-					successMsg = "Successfully pulled changes"
-				}
+			var successMsg string
+			if host != "" {
+				successMsg = fmt.Sprintf("Successfully pulled changes (host: %s)", host)
+			} else {
+				successMsg = "Successfully pulled changes"
+			}
 
-				symlinkText := fmt.Sprintf("Restored %d symlink", len(restored))
-				if len(restored) > 1 {
+			if len(result.Restored) > 0 {
+				symlinkText := fmt.Sprintf("Restored %d symlink", len(result.Restored))
+				if len(result.Restored) > 1 {
 					symlinkText += "s"
 				}
 				symlinkText += ":"
@@ -43,22 +43,17 @@ func newPullCmd() *cobra.Command {
 					WriteString("   ").
 					Writeln(Link(symlinkText))
 
-				for _, file := range restored {
+				for _, file := range result.Restored {
 					w.WriteString("      ").
 						Writeln(Sparkles(file))
 				}
+
+				writeBackupNotice(w, result.BackedUp)
 
 				w.WritelnString("").
 					WriteString("   ").
 					Writeln(Message{Text: "Your dotfiles are synced and ready!", Emoji: "🎉"})
 			} else {
-				var successMsg string
-				if host != "" {
-					successMsg = fmt.Sprintf("Successfully pulled changes (host: %s)", host)
-				} else {
-					successMsg = "Successfully pulled changes"
-				}
-
 				w.Writeln(Message{Text: successMsg, Emoji: "⬇️", Color: ColorBrightGreen, Bold: true}).
 					WriteString("   ").
 					Writeln(Success("All symlinks already in place")).
@@ -72,4 +67,29 @@ func newPullCmd() *cobra.Command {
 
 	cmd.Flags().StringP("host", "H", "", "Pull and restore symlinks for specific host (default: common configuration)")
 	return cmd
+}
+
+// writeBackupNotice renders a section listing files that were renamed to
+// <path>.lnk-backup so the user can decide what to do with them. No-op when
+// no backups occurred.
+func writeBackupNotice(w *Writer, backedUp []string) {
+	if len(backedUp) == 0 {
+		return
+	}
+
+	noun := "file"
+	if len(backedUp) > 1 {
+		noun = "files"
+	}
+
+	w.WritelnString("").
+		WriteString("   ").
+		Writeln(Warning(fmt.Sprintf("Backed up %d existing %s to .lnk-backup:", len(backedUp), noun)))
+
+	for _, file := range backedUp {
+		w.WriteString("      ").
+			Write(Plain("~/" + file)).
+			WriteString(" → ").
+			Writeln(Colored("~/"+file+".lnk-backup", ColorYellow))
+	}
 }

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -24,11 +24,11 @@ Use --force to remove a file from tracking even if the symlink no longer exists
 			filePath := args[0]
 			host, _ := cmd.Flags().GetString("host")
 			force, _ := cmd.Flags().GetBool("force")
-			lnk := lnk.NewLnk(lnk.WithHost(host))
+			l := lnk.NewLnk(lnk.WithHost(host))
 			w := GetWriter(cmd)
 
 			if force {
-				if err := lnk.RemoveForce(filePath); err != nil {
+				if err := l.RemoveForce(filePath); err != nil {
 					return err
 				}
 
@@ -44,24 +44,20 @@ Use --force to remove a file from tracking even if the symlink no longer exists
 				return w.Err()
 			}
 
-			if err := lnk.Remove(filePath); err != nil {
+			if err := l.Remove(filePath); err != nil {
 				return err
 			}
 
 			basename := filepath.Base(filePath)
 			if host != "" {
-				w.Writeln(Message{Text: fmt.Sprintf("Removed %s from lnk (host: %s)", basename, host), Emoji: "🗑️", Bold: true}).
-					WriteString("   ").
-					Write(Message{Text: fmt.Sprintf("~/.config/lnk/%s.lnk/%s", host, basename), Emoji: "↩️"}).
-					WriteString(" → ").
-					Writeln(Colored(filePath, ColorCyan))
+				w.Writeln(Message{Text: fmt.Sprintf("Removed %s from lnk (host: %s)", basename, host), Emoji: "🗑️", Bold: true})
 			} else {
-				w.Writeln(Message{Text: fmt.Sprintf("Removed %s from lnk", basename), Emoji: "🗑️", Bold: true}).
-					WriteString("   ").
-					Write(Message{Text: fmt.Sprintf("~/.config/lnk/%s", basename), Emoji: "↩️"}).
-					WriteString(" → ").
-					Writeln(Colored(filePath, ColorCyan))
+				w.Writeln(Message{Text: fmt.Sprintf("Removed %s from lnk", basename), Emoji: "🗑️", Bold: true})
 			}
+			w.WriteString("   ").
+				Write(Message{Text: lnk.FormatManagedPath(host, filePath), Emoji: "↩️"}).
+				WriteString(" → ").
+				Writeln(Colored(filePath, ColorCyan))
 
 			w.WriteString("   ").
 				Writeln(Message{Text: "Original file restored", Emoji: "📄"})

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -15,8 +15,11 @@ func newRemoveCmd() *cobra.Command {
 		Short: "🗑️ Remove a file from lnk management",
 		Long: `Removes a symlink and restores the original file from the lnk repository.
 
-Use --force to remove a file from tracking even if the symlink no longer exists
-(e.g., if you accidentally deleted the symlink without using lnk rm).`,
+Use --force for tracking cleanup only: it removes the entry from the .lnk index
+and the stored file from the repo without restoring anything in your home
+directory. This is intended for cases where the symlink is already missing
+(e.g., you deleted it manually) so the regular rm flow cannot run. --force
+does NOT recreate or move any file back into place.`,
 		Args:          cobra.ExactArgs(1),
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -39,7 +42,7 @@ Use --force to remove a file from tracking even if the symlink no longer exists
 					w.Writeln(Message{Text: fmt.Sprintf("Force removed %s from lnk", basename), Emoji: "🗑️", Bold: true})
 				}
 				w.WriteString("   ").
-					Writeln(Message{Text: "File removed from tracking", Emoji: "📋"})
+					Writeln(Message{Text: "Tracking cleanup only — no file was restored to your home directory", Emoji: "📋"})
 
 				return w.Err()
 			}
@@ -67,6 +70,6 @@ Use --force to remove a file from tracking even if the symlink no longer exists
 	}
 
 	cmd.Flags().StringP("host", "H", "", "Remove file from specific host configuration (default: common configuration)")
-	cmd.Flags().BoolP("force", "f", false, "Force removal from tracking even if symlink is missing")
+	cmd.Flags().BoolP("force", "f", false, "Tracking cleanup only: drop the entry and stored file without restoring anything in your home directory")
 	return cmd
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,7 +29,8 @@ func NewRootCommand() *cobra.Command {
 		Short: "🔗 Dotfiles, linked. No fluff.",
 		Long: `🔗 Lnk - Git-native dotfiles management that doesn't suck.
 
-Move your dotfiles to ~/.config/lnk, symlink them back, and use Git like normal.
+Move your dotfiles into a Git-managed repo (default: ~/.config/lnk; override with
+LNK_HOME or XDG_CONFIG_HOME), symlink them back, and use Git like normal.
 Supports both common configurations, host-specific setups, and bulk operations for multiple files.
 
 ✨ Examples:

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1227,9 +1227,10 @@ func (suite *CLITestSuite) TestDryRunRecursive() {
 	suite.Contains(output, "15 files", "Should show correct file count")
 	suite.Contains(output, "recursively", "Should indicate recursive mode")
 
-	// Should show some of the files
+	// Dry-run is a preview for verification, so all files are shown.
 	suite.Contains(output, "config1.json", "Should show first file")
 	suite.Contains(output, "config15.json", "Should show last file")
+	suite.NotContains(output, "more files", "Should not truncate dry-run preview")
 
 	// Verify no actual changes were made
 	for i := 1; i <= 15; i++ {
@@ -2408,6 +2409,148 @@ func (suite *CLITestSuite) TestStatusCommand_DirtyWithLnkHome_PrintsRepoPath() {
 	suite.Contains(output, "Repository has uncommitted changes")
 	suite.Contains(output, expectedRepo)
 	suite.NotContains(output, "~/.config/lnk")
+}
+
+// TestDryRun_SameBasenameDifferentDirs verifies that dry-run output uses
+// home-relative paths so files sharing a basename in different directories
+// remain distinguishable.
+func (suite *CLITestSuite) TestDryRun_SameBasenameDifferentDirs() {
+	err := suite.runCommand("init")
+	suite.Require().NoError(err)
+	suite.stdout.Reset()
+
+	dirA := filepath.Join(suite.tempDir, "a")
+	dirB := filepath.Join(suite.tempDir, "b")
+	suite.Require().NoError(os.MkdirAll(dirA, 0755))
+	suite.Require().NoError(os.MkdirAll(dirB, 0755))
+
+	fileA := filepath.Join(dirA, "config.json")
+	fileB := filepath.Join(dirB, "config.json")
+	suite.Require().NoError(os.WriteFile(fileA, []byte(`{"a":1}`), 0644))
+	suite.Require().NoError(os.WriteFile(fileB, []byte(`{"b":1}`), 0644))
+
+	err = suite.runCommand("add", "--dry-run", fileA, fileB)
+	suite.NoError(err)
+	output := suite.stdout.String()
+
+	suite.Contains(output, "Would add", "Should show dry-run preview")
+	suite.Contains(output, "~/a/config.json", "Should show first file with parent directory")
+	suite.Contains(output, "~/b/config.json", "Should show second file with parent directory")
+}
+
+// TestMultiAdd_SameBasenameDifferentDirs verifies that the success listing
+// for multi-file add disambiguates same-basename files via home-relative paths.
+func (suite *CLITestSuite) TestMultiAdd_SameBasenameDifferentDirs() {
+	err := suite.runCommand("init")
+	suite.Require().NoError(err)
+	suite.stdout.Reset()
+
+	dirA := filepath.Join(suite.tempDir, "a")
+	dirB := filepath.Join(suite.tempDir, "b")
+	suite.Require().NoError(os.MkdirAll(dirA, 0755))
+	suite.Require().NoError(os.MkdirAll(dirB, 0755))
+
+	fileA := filepath.Join(dirA, "config.json")
+	fileB := filepath.Join(dirB, "config.json")
+	suite.Require().NoError(os.WriteFile(fileA, []byte(`{"a":1}`), 0644))
+	suite.Require().NoError(os.WriteFile(fileB, []byte(`{"b":1}`), 0644))
+
+	err = suite.runCommand("add", fileA, fileB)
+	suite.NoError(err)
+	output := suite.stdout.String()
+
+	suite.Contains(output, "~/a/config.json", "Should show first source path")
+	suite.Contains(output, "~/b/config.json", "Should show second source path")
+	suite.Contains(output, "~/.config/lnk/a/config.json", "Should show first storage path")
+	suite.Contains(output, "~/.config/lnk/b/config.json", "Should show second storage path")
+}
+
+// TestRecursiveAdd_NonTTYNoCarriageReturn verifies that piped/non-TTY contexts
+// do not receive carriage-return progress redraws (which mangle log capture).
+func (suite *CLITestSuite) TestRecursiveAdd_NonTTYNoCarriageReturn() {
+	err := suite.runCommand("init")
+	suite.Require().NoError(err)
+	suite.stdout.Reset()
+
+	configDir := filepath.Join(suite.tempDir, ".config", "test-app")
+	suite.Require().NoError(os.MkdirAll(configDir, 0755))
+
+	for i := 0; i < 15; i++ {
+		file := filepath.Join(configDir, fmt.Sprintf("file%d.txt", i))
+		suite.Require().NoError(os.WriteFile(file, []byte(fmt.Sprintf("c%d", i)), 0644))
+	}
+
+	err = suite.runCommand("add", "--recursive", configDir)
+	suite.NoError(err)
+	output := suite.stdout.String()
+
+	suite.NotContains(output, "\r", "Non-TTY output should not include carriage-return redraws")
+	suite.NotContains(output, "Processing ", "Non-TTY output should not include progress redraws")
+}
+
+// TestRecursiveAdd_LargeBatchTruncatesListing verifies that recursive success
+// output stays compact for large batches via truncation + "more files" hint.
+func (suite *CLITestSuite) TestRecursiveAdd_LargeBatchTruncatesListing() {
+	err := suite.runCommand("init")
+	suite.Require().NoError(err)
+	suite.stdout.Reset()
+
+	configDir := filepath.Join(suite.tempDir, ".config", "many")
+	suite.Require().NoError(os.MkdirAll(configDir, 0755))
+
+	for i := 0; i < 12; i++ {
+		file := filepath.Join(configDir, fmt.Sprintf("file%d.txt", i))
+		suite.Require().NoError(os.WriteFile(file, []byte(fmt.Sprintf("c%d", i)), 0644))
+	}
+
+	err = suite.runCommand("add", "--recursive", configDir)
+	suite.NoError(err)
+	output := suite.stdout.String()
+
+	suite.Contains(output, "Added 12 files recursively", "Should show full count")
+	suite.Contains(output, "more files", "Should truncate to a 'more files' hint")
+}
+
+// TestRecursiveAdd_SameBasenameMultipleDirs verifies that recursive add with
+// same-basename files in different subdirs displays them unambiguously via
+// home-relative paths.
+func (suite *CLITestSuite) TestRecursiveAdd_SameBasenameMultipleDirs() {
+	err := suite.runCommand("init")
+	suite.Require().NoError(err)
+	suite.stdout.Reset()
+
+	// Create structure with same-basename files in different subdirs
+	dirA := filepath.Join(suite.tempDir, "configs", "app-a")
+	dirB := filepath.Join(suite.tempDir, "configs", "app-b")
+	suite.Require().NoError(os.MkdirAll(dirA, 0755))
+	suite.Require().NoError(os.MkdirAll(dirB, 0755))
+
+	configFileA := filepath.Join(dirA, "config.json")
+	configFileB := filepath.Join(dirB, "config.json")
+	suite.Require().NoError(os.WriteFile(configFileA, []byte(`{"app":"a"}`), 0644))
+	suite.Require().NoError(os.WriteFile(configFileB, []byte(`{"app":"b"}`), 0644))
+
+	// Recursive add from parent
+	parentDir := filepath.Join(suite.tempDir, "configs")
+	err = suite.runCommand("add", "--recursive", parentDir)
+	suite.NoError(err)
+	output := suite.stdout.String()
+
+	// Both files added
+	suite.Contains(output, "Added 2 files recursively", "Should show count of both files")
+
+	// Same-basename files are distinguishable by their directory path in the source
+	suite.Contains(output, "app-a/config.json", "Should show first config with parent dir")
+	suite.Contains(output, "app-b/config.json", "Should show second config with parent dir")
+
+	// Verify files are actually managed (symlinks created)
+	infoA, err := os.Lstat(configFileA)
+	suite.NoError(err)
+	suite.Equal(os.ModeSymlink, infoA.Mode()&os.ModeSymlink, "config.json in app-a should be symlink")
+
+	infoB, err := os.Lstat(configFileB)
+	suite.NoError(err)
+	suite.Equal(os.ModeSymlink, infoB.Mode()&os.ModeSymlink, "config.json in app-b should be symlink")
 }
 
 func TestCLISuite(t *testing.T) {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/suite"
+
+	"github.com/yarlson/lnk/internal/lnk"
 )
 
 type CLITestSuite struct {
@@ -2211,6 +2213,201 @@ func (suite *CLITestSuite) TestDoctorCommand_DryRun_BrokenSymlinks() {
 	// Verify NO actual fix — symlink should still be missing
 	_, err = os.Lstat(testFile)
 	suite.True(os.IsNotExist(err))
+}
+
+// TestAddCommand_AbsolutePath_PrintsCorrectDestination verifies that the destination
+// printed for `lnk add <abs-path>` is the canonical storage path, not the original
+// argument concatenated after the repo path.
+func (suite *CLITestSuite) TestAddCommand_AbsolutePath_PrintsCorrectDestination() {
+	err := suite.runCommand("init")
+	suite.Require().NoError(err)
+	suite.stdout.Reset()
+
+	testFile := filepath.Join(suite.tempDir, ".bashrc")
+	err = os.WriteFile(testFile, []byte("export PATH=/usr/local/bin:$PATH"), 0644)
+	suite.Require().NoError(err)
+
+	err = suite.runCommand("add", testFile)
+	suite.NoError(err)
+	output := suite.stdout.String()
+
+	suite.Contains(output, "~/.config/lnk/.bashrc")
+	// Bug regression: must not contain the absolute path glued to the repo path.
+	suite.NotContains(output, "~/.config/lnk"+testFile)
+	suite.NotContains(output, "~/.config/lnk//")
+}
+
+// TestAddCommand_LnkHome_PrintsCorrectDestination verifies that when LNK_HOME
+// points elsewhere, the destination reflects that path (not the default
+// ~/.config/lnk).
+func (suite *CLITestSuite) TestAddCommand_LnkHome_PrintsCorrectDestination() {
+	customRepo := filepath.Join(suite.tempDir, "custom-repo")
+	suite.T().Setenv("LNK_HOME", customRepo)
+
+	err := suite.runCommand("init")
+	suite.Require().NoError(err)
+	suite.stdout.Reset()
+
+	testFile := filepath.Join(suite.tempDir, ".bashrc")
+	err = os.WriteFile(testFile, []byte("export PATH=/usr/local/bin:$PATH"), 0644)
+	suite.Require().NoError(err)
+
+	err = suite.runCommand("add", testFile)
+	suite.NoError(err)
+	output := suite.stdout.String()
+
+	expected := lnk.DisplayPath(filepath.Join(customRepo, ".bashrc"))
+	suite.Contains(output, expected)
+	suite.NotContains(output, "~/.config/lnk")
+}
+
+// TestAddCommand_NestedPath_PrintsFullRelativePath verifies that nested files
+// show the full relative path under the repo, not just the basename.
+func (suite *CLITestSuite) TestAddCommand_NestedPath_PrintsFullRelativePath() {
+	err := suite.runCommand("init")
+	suite.Require().NoError(err)
+	suite.stdout.Reset()
+
+	nestedDir := filepath.Join(suite.tempDir, ".config", "nvim")
+	err = os.MkdirAll(nestedDir, 0755)
+	suite.Require().NoError(err)
+	nestedFile := filepath.Join(nestedDir, "init.lua")
+	err = os.WriteFile(nestedFile, []byte("vim.opt.number = true"), 0644)
+	suite.Require().NoError(err)
+
+	err = suite.runCommand("add", nestedFile)
+	suite.NoError(err)
+	output := suite.stdout.String()
+
+	suite.Contains(output, "~/.config/lnk/.config/nvim/init.lua")
+}
+
+// TestAddCommand_HostNestedPath_PrintsHostStoragePath verifies that host-scoped
+// nested files show <host>.lnk/<full-relative-path>.
+func (suite *CLITestSuite) TestAddCommand_HostNestedPath_PrintsHostStoragePath() {
+	err := suite.runCommand("init")
+	suite.Require().NoError(err)
+	suite.stdout.Reset()
+
+	nestedDir := filepath.Join(suite.tempDir, ".config", "nvim")
+	err = os.MkdirAll(nestedDir, 0755)
+	suite.Require().NoError(err)
+	nestedFile := filepath.Join(nestedDir, "init.lua")
+	err = os.WriteFile(nestedFile, []byte("vim.opt.number = true"), 0644)
+	suite.Require().NoError(err)
+
+	err = suite.runCommand("add", "--host", "work", nestedFile)
+	suite.NoError(err)
+	output := suite.stdout.String()
+
+	suite.Contains(output, "~/.config/lnk/work.lnk/.config/nvim/init.lua")
+}
+
+// TestAddCommand_RecursiveNestedPath_PrintsFullRelativePath verifies that recursive add
+// displays the full relative path for nested files, not just basenames.
+func (suite *CLITestSuite) TestAddCommand_RecursiveNestedPath_PrintsFullRelativePath() {
+	err := suite.runCommand("init")
+	suite.Require().NoError(err)
+	suite.stdout.Reset()
+
+	docsDir := filepath.Join(suite.tempDir, ".docs")
+	err = os.MkdirAll(docsDir, 0755)
+	suite.Require().NoError(err)
+
+	readmeFile := filepath.Join(docsDir, "README.md")
+	err = os.WriteFile(readmeFile, []byte("# Documentation"), 0644)
+	suite.Require().NoError(err)
+
+	err = suite.runCommand("add", "--recursive", docsDir)
+	suite.NoError(err)
+	output := suite.stdout.String()
+
+	suite.Contains(output, "~/.config/lnk/.docs/README.md")
+}
+
+// TestRemoveCommand_NestedPath_PrintsCanonicalSourcePath verifies that `lnk rm`
+// prints the actual storage path (using the full relative path), not just the
+// basename glued onto ~/.config/lnk.
+func (suite *CLITestSuite) TestRemoveCommand_NestedPath_PrintsCanonicalSourcePath() {
+	err := suite.runCommand("init")
+	suite.Require().NoError(err)
+
+	nestedDir := filepath.Join(suite.tempDir, ".config", "nvim")
+	err = os.MkdirAll(nestedDir, 0755)
+	suite.Require().NoError(err)
+	nestedFile := filepath.Join(nestedDir, "init.lua")
+	err = os.WriteFile(nestedFile, []byte("vim.opt.number = true"), 0644)
+	suite.Require().NoError(err)
+
+	err = suite.runCommand("add", nestedFile)
+	suite.Require().NoError(err)
+	suite.stdout.Reset()
+
+	err = suite.runCommand("rm", nestedFile)
+	suite.NoError(err)
+	output := suite.stdout.String()
+
+	suite.Contains(output, "~/.config/lnk/.config/nvim/init.lua")
+}
+
+// TestRemoveCommand_HostNestedPath_PrintsHostStoragePath verifies that a
+// host-scoped `lnk rm` prints the canonical `<host>.lnk/<full-relative-path>`
+// location.
+func (suite *CLITestSuite) TestRemoveCommand_HostNestedPath_PrintsHostStoragePath() {
+	err := suite.runCommand("init")
+	suite.Require().NoError(err)
+
+	nestedDir := filepath.Join(suite.tempDir, ".config", "nvim")
+	err = os.MkdirAll(nestedDir, 0755)
+	suite.Require().NoError(err)
+	nestedFile := filepath.Join(nestedDir, "init.lua")
+	err = os.WriteFile(nestedFile, []byte("vim.opt.number = true"), 0644)
+	suite.Require().NoError(err)
+
+	err = suite.runCommand("add", "--host", "work", nestedFile)
+	suite.Require().NoError(err)
+	suite.stdout.Reset()
+
+	err = suite.runCommand("rm", "--host", "work", nestedFile)
+	suite.NoError(err)
+	output := suite.stdout.String()
+
+	suite.Contains(output, "~/.config/lnk/work.lnk/.config/nvim/init.lua")
+}
+
+// TestStatusCommand_DirtyWithLnkHome_PrintsRepoPath verifies the dirty-status
+// hint references the actual repo path, not a hardcoded ~/.config/lnk.
+func (suite *CLITestSuite) TestStatusCommand_DirtyWithLnkHome_PrintsRepoPath() {
+	customRepo := filepath.Join(suite.tempDir, "custom-repo")
+	suite.T().Setenv("LNK_HOME", customRepo)
+
+	err := suite.runCommand("init")
+	suite.Require().NoError(err)
+	suite.stdout.Reset()
+
+	testFile := filepath.Join(suite.tempDir, ".bashrc")
+	err = os.WriteFile(testFile, []byte("a"), 0644)
+	suite.Require().NoError(err)
+	err = suite.runCommand("add", testFile)
+	suite.Require().NoError(err)
+	suite.stdout.Reset()
+
+	cmd := exec.Command("git", "remote", "add", "origin", "https://github.com/test/dotfiles.git")
+	cmd.Dir = customRepo
+	err = cmd.Run()
+	suite.Require().NoError(err)
+
+	err = os.WriteFile(testFile, []byte("b"), 0644)
+	suite.Require().NoError(err)
+
+	err = suite.runCommand("status")
+	suite.NoError(err)
+	output := suite.stdout.String()
+
+	expectedRepo := lnk.DisplayPath(customRepo)
+	suite.Contains(output, "Repository has uncommitted changes")
+	suite.Contains(output, expectedRepo)
+	suite.NotContains(output, "~/.config/lnk")
 }
 
 func TestCLISuite(t *testing.T) {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -2652,30 +2652,36 @@ func (suite *CLITestSuite) TestDiffCommand_ColorsAlways() {
 	suite.Contains(output, "\033[", "--colors always must emit ANSI color codes")
 }
 
-// TestDiffCommand_QuietSuppressesOutput verifies that --quiet suppresses all
-// diff output (both the no-changes message and the diff body).
+// TestDiffCommand_QuietSuppressesOutput verifies that --quiet suppresses
+// all diff output and that dirty state is signalled via a non-zero exit
+// (a non-nil error from RunE) rather than printed text.
 func (suite *CLITestSuite) TestDiffCommand_QuietSuppressesOutput() {
 	err := suite.runCommand("init")
 	suite.Require().NoError(err)
 	suite.stdout.Reset()
+	suite.stderr.Reset()
 
 	testFile := filepath.Join(suite.tempDir, ".bashrc")
 	suite.Require().NoError(os.WriteFile(testFile, []byte("PATH=/bin"), 0644))
 	suite.Require().NoError(suite.runCommand("add", testFile))
 	suite.stdout.Reset()
+	suite.stderr.Reset()
 
-	// After add the working tree is clean — exercise the "no changes" branch.
+	// Clean working tree — exit 0, no output.
 	err = suite.runCommand("--quiet", "diff")
-	suite.NoError(err)
+	suite.NoError(err, "--quiet diff must succeed on a clean repo")
 	suite.Empty(suite.stdout.String(), "--quiet must suppress 'no changes' message")
+	suite.Empty(suite.stderr.String(), "--quiet must not write to stderr on a clean repo")
 
-	// Now introduce uncommitted changes and exercise the diff-body branch.
+	// Dirty working tree — non-zero exit, still no output.
 	suite.Require().NoError(os.WriteFile(testFile, []byte("PATH=/bin\nEDITOR=vim"), 0644))
 	suite.stdout.Reset()
+	suite.stderr.Reset()
 
 	err = suite.runCommand("--quiet", "diff")
-	suite.NoError(err)
+	suite.Error(err, "--quiet diff must signal dirty state via non-zero exit")
 	suite.Empty(suite.stdout.String(), "--quiet must suppress diff output entirely")
+	suite.Empty(suite.stderr.String(), "--quiet must not write the dirty error to stderr")
 }
 
 // setupRemoteWithFiles creates a bare remote and seeds it with the given files

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -2648,6 +2648,171 @@ func (suite *CLITestSuite) TestDiffCommand_QuietSuppressesOutput() {
 	suite.Empty(suite.stdout.String(), "--quiet must suppress diff output entirely")
 }
 
+// setupRemoteWithFiles creates a bare remote and seeds it with the given files
+// (path -> content). Returns the bare remote path so callers can pass it to
+// `init -r`. Used by the host-flow guidance tests.
+func (suite *CLITestSuite) setupRemoteWithFiles(label string, files map[string]string) string {
+	remoteDir := filepath.Join(suite.tempDir, "remote-"+label)
+	suite.Require().NoError(os.MkdirAll(remoteDir, 0755))
+
+	cmd := exec.Command("git", "init", "--bare", "--initial-branch=main")
+	cmd.Dir = remoteDir
+	suite.Require().NoError(cmd.Run())
+
+	workingDir := filepath.Join(suite.tempDir, "working-"+label)
+	suite.Require().NoError(os.MkdirAll(workingDir, 0755))
+
+	cmd = exec.Command("git", "clone", remoteDir, workingDir)
+	suite.Require().NoError(cmd.Run())
+
+	for relPath, content := range files {
+		fullPath := filepath.Join(workingDir, relPath)
+		suite.Require().NoError(os.MkdirAll(filepath.Dir(fullPath), 0755))
+		suite.Require().NoError(os.WriteFile(fullPath, []byte(content), 0644))
+	}
+
+	cmd = exec.Command("git", "add", ".")
+	cmd.Dir = workingDir
+	suite.Require().NoError(cmd.Run())
+
+	cmd = exec.Command("git", "-c", "user.email=test@example.com", "-c", "user.name=Test User", "commit", "-m", "lnk: seed")
+	cmd.Dir = workingDir
+	suite.Require().NoError(cmd.Run())
+
+	cmd = exec.Command("git", "push", "origin", "main")
+	cmd.Dir = workingDir
+	suite.Require().NoError(cmd.Run())
+
+	return remoteDir
+}
+
+// TestInitWithRemote_HostHints_Mixed verifies that `init -r` next-step output
+// surfaces a `lnk pull --host <name>` hint for every `.lnk.<host>` file present
+// in the cloned repo, in addition to the common pull/add hints.
+func (suite *CLITestSuite) TestInitWithRemote_HostHints_Mixed() {
+	remoteDir := suite.setupRemoteWithFiles("mixed", map[string]string{
+		".lnk":              ".bashrc\n",
+		".bashrc":           "export PATH",
+		".lnk.work":         ".vimrc\n",
+		"work.lnk/.vimrc":   "set number",
+		".lnk.laptop":       ".zshrc\n",
+		"laptop.lnk/.zshrc": "# zsh",
+	})
+
+	err := suite.runCommand("init", "-r", remoteDir, "--no-bootstrap")
+	suite.NoError(err)
+
+	output := suite.stdout.String()
+	suite.Contains(output, "Run lnk pull --host work to restore the work configuration")
+	suite.Contains(output, "Run lnk pull --host laptop to restore the laptop configuration")
+	suite.Contains(output, "lnk pull")
+	suite.Contains(output, "lnk add <file>")
+}
+
+// TestInitWithRemote_HostHints_HostOnly verifies that a repo containing only
+// host-specific configs (no common `.lnk`) still surfaces per-host pull hints.
+func (suite *CLITestSuite) TestInitWithRemote_HostHints_HostOnly() {
+	remoteDir := suite.setupRemoteWithFiles("hostonly", map[string]string{
+		".lnk.work":       ".vimrc\n",
+		"work.lnk/.vimrc": "set number",
+	})
+
+	err := suite.runCommand("init", "-r", remoteDir, "--no-bootstrap")
+	suite.NoError(err)
+
+	output := suite.stdout.String()
+	suite.Contains(output, "Run lnk pull --host work to restore the work configuration")
+}
+
+// TestInitWithRemote_HostHints_CommonOnly verifies that a repo with no host
+// configs does not emit any `--host` next-step hints.
+func (suite *CLITestSuite) TestInitWithRemote_HostHints_CommonOnly() {
+	remoteDir := suite.setupRemoteWithFiles("commononly", map[string]string{
+		".lnk":    ".bashrc\n",
+		".bashrc": "export PATH",
+	})
+
+	err := suite.runCommand("init", "-r", remoteDir, "--no-bootstrap")
+	suite.NoError(err)
+
+	output := suite.stdout.String()
+	suite.Contains(output, "lnk pull")
+	suite.Contains(output, "lnk add <file>")
+	suite.NotContains(output, "--host", "Common-only repo must not emit host-specific next-step hints")
+}
+
+// TestListAll_PerHostPullHint verifies that `list --all` emits a per-host hint
+// pointing to `lnk pull --host <name>` for each discovered host section.
+func (suite *CLITestSuite) TestListAll_PerHostPullHint() {
+	suite.Require().NoError(suite.runCommand("init"))
+	suite.stdout.Reset()
+
+	bashrc := filepath.Join(suite.tempDir, ".bashrc")
+	suite.Require().NoError(os.WriteFile(bashrc, []byte("export PATH"), 0644))
+	suite.Require().NoError(suite.runCommand("add", bashrc))
+	suite.stdout.Reset()
+
+	vimrc := filepath.Join(suite.tempDir, ".vimrc")
+	suite.Require().NoError(os.WriteFile(vimrc, []byte("set number"), 0644))
+	suite.Require().NoError(suite.runCommand("add", "--host", "work", vimrc))
+	suite.stdout.Reset()
+
+	zshrc := filepath.Join(suite.tempDir, ".zshrc")
+	suite.Require().NoError(os.WriteFile(zshrc, []byte("# zsh"), 0644))
+	suite.Require().NoError(suite.runCommand("add", "--host", "laptop", zshrc))
+	suite.stdout.Reset()
+
+	err := suite.runCommand("list", "--all")
+	suite.NoError(err)
+	output := suite.stdout.String()
+
+	suite.Contains(output, "Host: work")
+	suite.Contains(output, "Host: laptop")
+	suite.Contains(output, "lnk pull --host work")
+	suite.Contains(output, "lnk pull --host laptop")
+	suite.Contains(output, "lnk list --host <hostname>")
+}
+
+// TestListAll_CommonOnlyNoHostHint verifies that `list --all` on a repo with
+// only common managed items does not emit any per-host pull hint.
+func (suite *CLITestSuite) TestListAll_CommonOnlyNoHostHint() {
+	suite.Require().NoError(suite.runCommand("init"))
+	suite.stdout.Reset()
+
+	bashrc := filepath.Join(suite.tempDir, ".bashrc")
+	suite.Require().NoError(os.WriteFile(bashrc, []byte("export PATH"), 0644))
+	suite.Require().NoError(suite.runCommand("add", bashrc))
+	suite.stdout.Reset()
+
+	err := suite.runCommand("list", "--all")
+	suite.NoError(err)
+	output := suite.stdout.String()
+
+	suite.Contains(output, "Common configuration")
+	suite.NotContains(output, "lnk pull --host", "Common-only repo must not emit per-host pull hints")
+}
+
+// TestListAll_HostOnlyEmitsHint verifies that `list --all` on a repo with only
+// host-specific configs (no common items) still shows the host section and the
+// per-host pull hint.
+func (suite *CLITestSuite) TestListAll_HostOnlyEmitsHint() {
+	suite.Require().NoError(suite.runCommand("init"))
+	suite.stdout.Reset()
+
+	vimrc := filepath.Join(suite.tempDir, ".vimrc")
+	suite.Require().NoError(os.WriteFile(vimrc, []byte("set number"), 0644))
+	suite.Require().NoError(suite.runCommand("add", "--host", "work", vimrc))
+	suite.stdout.Reset()
+
+	err := suite.runCommand("list", "--all")
+	suite.NoError(err)
+	output := suite.stdout.String()
+
+	suite.Contains(output, "Host: work")
+	suite.Contains(output, "lnk pull --host work")
+	suite.Contains(output, "(no files)", "Empty common section should still render")
+}
+
 func TestCLISuite(t *testing.T) {
 	suite.Run(t, new(CLITestSuite))
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -796,6 +796,34 @@ touch bootstrap-ran.txt
 	suite.FileExists(markerFile)
 }
 
+// TestBootstrapCommand_QuietSuppressesScriptOutput verifies that --quiet
+// silences not only the framing output but also stdout/stderr from the
+// bootstrap script itself, while still actually executing it.
+func (suite *CLITestSuite) TestBootstrapCommand_QuietSuppressesScriptOutput() {
+	err := suite.runCommand("init")
+	suite.Require().NoError(err)
+	suite.stdout.Reset()
+	suite.stderr.Reset()
+
+	lnkDir := filepath.Join(suite.tempDir, ".config", "lnk")
+	bootstrapScript := filepath.Join(lnkDir, "bootstrap.sh")
+	scriptContent := `#!/bin/bash
+echo "BOOT_STDOUT_LEAK"
+echo "BOOT_STDERR_LEAK" >&2
+touch quiet-bootstrap-ran.txt
+`
+	err = os.WriteFile(bootstrapScript, []byte(scriptContent), 0755)
+	suite.Require().NoError(err)
+
+	err = suite.runCommand("--quiet", "bootstrap")
+	suite.NoError(err)
+	suite.Empty(suite.stdout.String(), "--quiet must suppress framing and script stdout")
+	suite.NotContains(suite.stderr.String(), "BOOT_STDERR_LEAK", "--quiet must suppress script stderr")
+
+	// Marker proves the script actually executed even with --quiet.
+	suite.FileExists(filepath.Join(lnkDir, "quiet-bootstrap-ran.txt"))
+}
+
 func (suite *CLITestSuite) TestInitWithBootstrap() {
 	// Create a temporary remote repository with bootstrap script
 	remoteDir := filepath.Join(suite.tempDir, "remote")

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -13,6 +14,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/yarlson/lnk/internal/lnk"
+	error2 "github.com/yarlson/lnk/internal/lnkerror"
 )
 
 type CLITestSuite struct {
@@ -2551,6 +2553,99 @@ func (suite *CLITestSuite) TestRecursiveAdd_SameBasenameMultipleDirs() {
 	infoB, err := os.Lstat(configFileB)
 	suite.NoError(err)
 	suite.Equal(os.ModeSymlink, infoB.Mode()&os.ModeSymlink, "config.json in app-b should be symlink")
+}
+
+// TestDryRunDuplicateError_NoEmbeddedFormatting verifies that the duplicate-path
+// error from `add --dry-run` carries no embedded ANSI/emoji and is shaped as a
+// structured lnkerror so DisplayError can render it like other CLI errors.
+func (suite *CLITestSuite) TestDryRunDuplicateError_NoEmbeddedFormatting() {
+	err := suite.runCommand("init")
+	suite.Require().NoError(err)
+	suite.stdout.Reset()
+
+	testFile := filepath.Join(suite.tempDir, ".bashrc")
+	suite.Require().NoError(os.WriteFile(testFile, []byte("PATH=/bin"), 0644))
+	suite.Require().NoError(suite.runCommand("add", testFile))
+	suite.stdout.Reset()
+
+	err = suite.runCommand("add", "--dry-run", testFile)
+	suite.Require().Error(err)
+
+	msg := err.Error()
+	suite.NotContains(msg, "\033[", "Error must not embed ANSI color codes")
+	suite.NotContains(msg, "❌", "Error must not embed emoji")
+	suite.Contains(msg, "already managed", "Error must still convey duplicate condition")
+
+	var lnkErr *error2.Error
+	suite.Require().True(errors.As(err, &lnkErr), "Error must be a structured lnkerror")
+	suite.Equal(error2.ErrAlreadyManaged, lnkErr.Err, "Should wrap ErrAlreadyManaged sentinel")
+	suite.NotEmpty(lnkErr.Path, "Structured error should carry the offending path")
+}
+
+// TestDiffCommand_ColorsNever verifies that --colors never produces no ANSI
+// escape codes in diff output even when there are uncommitted changes.
+func (suite *CLITestSuite) TestDiffCommand_ColorsNever() {
+	err := suite.runCommand("init")
+	suite.Require().NoError(err)
+	suite.stdout.Reset()
+
+	testFile := filepath.Join(suite.tempDir, ".bashrc")
+	suite.Require().NoError(os.WriteFile(testFile, []byte("PATH=/bin"), 0644))
+	suite.Require().NoError(suite.runCommand("add", testFile))
+	suite.Require().NoError(os.WriteFile(testFile, []byte("PATH=/bin\nEDITOR=vim"), 0644))
+	suite.stdout.Reset()
+
+	err = suite.runCommand("--colors", "never", "diff")
+	suite.NoError(err)
+	output := suite.stdout.String()
+	suite.Contains(output, "EDITOR=vim", "Diff should still include changed content")
+	suite.NotContains(output, "\033[", "--colors never must not emit ANSI color codes")
+}
+
+// TestDiffCommand_ColorsAlways verifies that --colors always forces ANSI color
+// codes into the diff output even when stdout is not a terminal.
+func (suite *CLITestSuite) TestDiffCommand_ColorsAlways() {
+	err := suite.runCommand("init")
+	suite.Require().NoError(err)
+	suite.stdout.Reset()
+
+	testFile := filepath.Join(suite.tempDir, ".bashrc")
+	suite.Require().NoError(os.WriteFile(testFile, []byte("PATH=/bin"), 0644))
+	suite.Require().NoError(suite.runCommand("add", testFile))
+	suite.Require().NoError(os.WriteFile(testFile, []byte("PATH=/bin\nEDITOR=vim"), 0644))
+	suite.stdout.Reset()
+
+	err = suite.runCommand("--colors", "always", "diff")
+	suite.NoError(err)
+	output := suite.stdout.String()
+	suite.Contains(output, "EDITOR=vim", "Diff should include changed content")
+	suite.Contains(output, "\033[", "--colors always must emit ANSI color codes")
+}
+
+// TestDiffCommand_QuietSuppressesOutput verifies that --quiet suppresses all
+// diff output (both the no-changes message and the diff body).
+func (suite *CLITestSuite) TestDiffCommand_QuietSuppressesOutput() {
+	err := suite.runCommand("init")
+	suite.Require().NoError(err)
+	suite.stdout.Reset()
+
+	testFile := filepath.Join(suite.tempDir, ".bashrc")
+	suite.Require().NoError(os.WriteFile(testFile, []byte("PATH=/bin"), 0644))
+	suite.Require().NoError(suite.runCommand("add", testFile))
+	suite.stdout.Reset()
+
+	// After add the working tree is clean — exercise the "no changes" branch.
+	err = suite.runCommand("--quiet", "diff")
+	suite.NoError(err)
+	suite.Empty(suite.stdout.String(), "--quiet must suppress 'no changes' message")
+
+	// Now introduce uncommitted changes and exercise the diff-body branch.
+	suite.Require().NoError(os.WriteFile(testFile, []byte("PATH=/bin\nEDITOR=vim"), 0644))
+	suite.stdout.Reset()
+
+	err = suite.runCommand("--quiet", "diff")
+	suite.NoError(err)
+	suite.Empty(suite.stdout.String(), "--quiet must suppress diff output entirely")
 }
 
 func TestCLISuite(t *testing.T) {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -164,10 +164,12 @@ func (suite *CLITestSuite) TestStatusCommand() {
 	suite.Require().NoError(err)
 	suite.stdout.Reset()
 
-	// Test status without remote - should fail
+	// Status without a remote should still succeed and report local state.
 	err = suite.runCommand("status")
-	suite.Error(err)
-	suite.Contains(err.Error(), "No remote repository is configured")
+	suite.NoError(err)
+	output := suite.stdout.String()
+	suite.Contains(output, "No remote configured")
+	suite.Contains(output, "git remote add origin")
 }
 
 func (suite *CLITestSuite) TestListCommand() {
@@ -2811,6 +2813,174 @@ func (suite *CLITestSuite) TestListAll_HostOnlyEmitsHint() {
 	suite.Contains(output, "Host: work")
 	suite.Contains(output, "lnk pull --host work")
 	suite.Contains(output, "(no files)", "Empty common section should still render")
+}
+
+// TASK5: Safety visibility & no-remote status
+
+// TestStatusCommand_NoRemote_DirtyShowsLocalState verifies that running
+// `lnk status` against a repo with no remote configured still reports the
+// dirty state and points the user at the right next step (adding a remote).
+func (suite *CLITestSuite) TestStatusCommand_NoRemote_DirtyShowsLocalState() {
+	err := suite.runCommand("init")
+	suite.Require().NoError(err)
+	suite.stdout.Reset()
+
+	testFile := filepath.Join(suite.tempDir, ".bashrc")
+	err = os.WriteFile(testFile, []byte("export PATH"), 0644)
+	suite.Require().NoError(err)
+	err = suite.runCommand("add", testFile)
+	suite.Require().NoError(err)
+	suite.stdout.Reset()
+
+	// Make the working tree dirty by editing the managed file.
+	err = os.WriteFile(testFile, []byte("export PATH=/usr/local/bin"), 0644)
+	suite.Require().NoError(err)
+
+	err = suite.runCommand("status")
+	suite.NoError(err)
+	output := suite.stdout.String()
+	suite.Contains(output, "Repository has uncommitted changes")
+	suite.Contains(output, "No remote configured")
+	suite.Contains(output, "git remote add origin")
+}
+
+// TestStatusCommand_NoRemote_CleanShowsLocalCommits verifies that a clean
+// repo with local commits but no remote reports those commits as local-only
+// instead of failing.
+func (suite *CLITestSuite) TestStatusCommand_NoRemote_CleanShowsLocalCommits() {
+	err := suite.runCommand("init")
+	suite.Require().NoError(err)
+	suite.stdout.Reset()
+
+	testFile := filepath.Join(suite.tempDir, ".bashrc")
+	err = os.WriteFile(testFile, []byte("export PATH"), 0644)
+	suite.Require().NoError(err)
+	err = suite.runCommand("add", testFile)
+	suite.Require().NoError(err)
+	suite.stdout.Reset()
+
+	err = suite.runCommand("status")
+	suite.NoError(err)
+	output := suite.stdout.String()
+	suite.Contains(output, "Working tree is clean")
+	suite.Contains(output, "No remote configured")
+	suite.Contains(output, "1 local commit")
+	suite.Contains(output, "git remote add origin")
+}
+
+// TestRemoveCommand_ForceMessagingExplainsTrackingCleanup verifies that the
+// success output for `rm --force` makes it clear nothing was restored to the
+// user's home directory — this is tracking cleanup, not a normal restore.
+func (suite *CLITestSuite) TestRemoveCommand_ForceMessagingExplainsTrackingCleanup() {
+	err := suite.runCommand("init")
+	suite.Require().NoError(err)
+
+	testFile := filepath.Join(suite.tempDir, ".bashrc")
+	err = os.WriteFile(testFile, []byte("export PATH"), 0644)
+	suite.Require().NoError(err)
+	err = suite.runCommand("add", testFile)
+	suite.Require().NoError(err)
+
+	// Simulate user mistake: delete the symlink without `lnk rm`.
+	err = os.Remove(testFile)
+	suite.Require().NoError(err)
+	suite.stdout.Reset()
+
+	err = suite.runCommand("rm", "--force", testFile)
+	suite.Require().NoError(err)
+	output := suite.stdout.String()
+	suite.Contains(output, "Force removed")
+	suite.Contains(output, "Tracking cleanup only")
+	suite.Contains(output, "no file was restored")
+	suite.NotContains(output, "Original file restored")
+}
+
+// TestRemoveCommand_HelpText_ExplainsForceIsTrackingCleanup verifies the
+// command help text distinguishes --force as tracking cleanup, so users do
+// not expect normal-restore semantics.
+func (suite *CLITestSuite) TestRemoveCommand_HelpText_ExplainsForceIsTrackingCleanup() {
+	err := suite.runCommand("rm", "--help")
+	suite.NoError(err)
+	output := suite.stdout.String()
+	suite.Contains(output, "tracking cleanup")
+	suite.Contains(output, "does NOT recreate")
+}
+
+// TestPullCommand_ReportsBackup verifies that `lnk pull` reports when a
+// pre-existing real file at the symlink target was renamed to .lnk-backup
+// instead of being silently overwritten.
+func (suite *CLITestSuite) TestPullCommand_ReportsBackup() {
+	// Set up a remote we can pull from.
+	remoteDir := filepath.Join(suite.tempDir, "remote.git")
+	suite.Require().NoError(os.MkdirAll(remoteDir, 0755))
+	cmd := exec.Command("git", "init", "--bare", "--initial-branch=main")
+	cmd.Dir = remoteDir
+	suite.Require().NoError(cmd.Run())
+
+	// Init the lnk repo with that remote and add a managed file so
+	// the remote has the .lnk index and stored content to pull back.
+	err := suite.runCommand("init", "--remote", remoteDir)
+	suite.Require().NoError(err)
+
+	managed := filepath.Join(suite.tempDir, ".bashrc")
+	suite.Require().NoError(os.WriteFile(managed, []byte("export PATH"), 0644))
+	err = suite.runCommand("add", managed)
+	suite.Require().NoError(err)
+	err = suite.runCommand("push", "seed")
+	suite.Require().NoError(err)
+
+	// Replace the symlink with a real file so RestoreSymlinks must back it up.
+	suite.Require().NoError(os.Remove(managed))
+	suite.Require().NoError(os.WriteFile(managed, []byte("preexisting"), 0644))
+	defer func() {
+		_ = os.Remove(managed + ".lnk-backup")
+	}()
+	suite.stdout.Reset()
+
+	err = suite.runCommand("pull")
+	suite.Require().NoError(err)
+	output := suite.stdout.String()
+	suite.Contains(output, "Backed up 1 existing file to .lnk-backup")
+	suite.Contains(output, ".bashrc")
+	suite.Contains(output, ".lnk-backup")
+
+	// Backup file must exist with original content.
+	backup := managed + ".lnk-backup"
+	suite.FileExists(backup)
+	content, readErr := os.ReadFile(backup)
+	suite.Require().NoError(readErr)
+	suite.Equal("preexisting", string(content))
+}
+
+// TestDoctorCommand_ReportsBackup verifies that `lnk doctor` reports when
+// fixing a broken symlink required renaming a pre-existing real file to
+// .lnk-backup.
+func (suite *CLITestSuite) TestDoctorCommand_ReportsBackup() {
+	err := suite.runCommand("init")
+	suite.Require().NoError(err)
+
+	managed := filepath.Join(suite.tempDir, ".bashrc")
+	suite.Require().NoError(os.WriteFile(managed, []byte("export PATH"), 0644))
+	err = suite.runCommand("add", managed)
+	suite.Require().NoError(err)
+
+	// Replace the symlink with a real file so doctor must back it up.
+	suite.Require().NoError(os.Remove(managed))
+	suite.Require().NoError(os.WriteFile(managed, []byte("preexisting"), 0644))
+	defer func() {
+		_ = os.Remove(managed + ".lnk-backup")
+	}()
+	suite.stdout.Reset()
+
+	err = suite.runCommand("doctor")
+	suite.Require().NoError(err)
+	output := suite.stdout.String()
+	suite.Contains(output, "Restored 1 broken symlink")
+	suite.Contains(output, "Backed up 1 existing file to .lnk-backup")
+	suite.Contains(output, ".bashrc")
+
+	// Verify the backup file actually exists.
+	suite.FileExists(managed + ".lnk-backup")
 }
 
 func TestCLISuite(t *testing.T) {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -16,8 +16,8 @@ func newStatusCmd() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			lnk := lnk.NewLnk()
-			status, err := lnk.Status()
+			l := lnk.NewLnk()
+			status, err := l.Status()
 			if err != nil {
 				return err
 			}
@@ -41,6 +41,8 @@ func newStatusCmd() *cobra.Command {
 func displayDirtyStatus(cmd *cobra.Command, status *lnk.StatusInfo) {
 	w := GetWriter(cmd)
 
+	repoDisplay := lnk.DisplayPath(lnk.GetRepoPath())
+
 	w.Writeln(Warning("Repository has uncommitted changes")).
 		WriteString("   ").
 		Write(Message{Text: "Remote: ", Emoji: "📡"}).
@@ -51,7 +53,7 @@ func displayDirtyStatus(cmd *cobra.Command, status *lnk.StatusInfo) {
 			Write(Info("Run ")).
 			Write(Bold("git add && git commit")).
 			WriteString(" in ").
-			Write(Colored("~/.config/lnk", ColorCyan)).
+			Write(Colored(repoDisplay, ColorCyan)).
 			WriteString(" or ").
 			Write(Bold("lnk push")).
 			WritelnString(" to commit changes")
@@ -64,7 +66,7 @@ func displayDirtyStatus(cmd *cobra.Command, status *lnk.StatusInfo) {
 		Write(Info("Run ")).
 		Write(Bold("git add && git commit")).
 		WriteString(" in ").
-		Write(Colored("~/.config/lnk", ColorCyan)).
+		Write(Colored(repoDisplay, ColorCyan)).
 		WriteString(" or ").
 		Write(Bold("lnk push")).
 		WritelnString(" to commit changes")

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -22,6 +22,11 @@ func newStatusCmd() *cobra.Command {
 				return err
 			}
 
+			if status.Remote == "" {
+				displayNoRemoteStatus(cmd, status)
+				return nil
+			}
+
 			if status.Dirty {
 				displayDirtyStatus(cmd, status)
 				return nil
@@ -136,4 +141,40 @@ func getCommitText(count int) string {
 		return "commit"
 	}
 	return "commits"
+}
+
+// displayNoRemoteStatus renders status for a repository that has no remote
+// configured. We still report local state (dirty / clean, local commit count)
+// and guide the user toward adding a remote.
+func displayNoRemoteStatus(cmd *cobra.Command, status *lnk.StatusInfo) {
+	w := GetWriter(cmd)
+
+	repoDisplay := lnk.DisplayPath(lnk.GetRepoPath())
+
+	if status.Dirty {
+		w.Writeln(Warning("Repository has uncommitted changes")).
+			WriteString("   ").
+			Writeln(Message{Text: "No remote configured", Emoji: "📡", Color: ColorGray})
+	} else {
+		w.Writeln(Success("Working tree is clean")).
+			WriteString("   ").
+			Writeln(Message{Text: "No remote configured", Emoji: "📡", Color: ColorGray})
+	}
+
+	if status.Ahead > 0 {
+		commitText := getCommitText(status.Ahead)
+		w.WriteString("   ").
+			Writeln(Message{Text: fmt.Sprintf("%d local %s (no remote to compare against)", status.Ahead, commitText), Emoji: "⬆️", Color: ColorBrightYellow, Bold: true})
+	}
+
+	w.WritelnString("").
+		Write(Info("Add a remote to enable ")).
+		Write(Bold("lnk push")).
+		WriteString(" / ").
+		Write(Bold("lnk pull")).
+		WritelnString("").
+		WriteString("   ").
+		Write(Bold("git remote add origin <url>")).
+		WriteString(" in ").
+		Writeln(Colored(repoDisplay, ColorCyan))
 }

--- a/docs/context/architecture.md
+++ b/docs/context/architecture.md
@@ -29,7 +29,7 @@ Re-exported from the facade for backwards compatibility:
 
 - Sentinel errors (`ErrAlreadyManaged`, `ErrNotInitialized`, etc.) — re-exported from `lnkerror`.
 - Type aliases: `ProgressCallback = filemanager.ProgressCallback`, `StatusInfo = syncer.StatusInfo`, `DoctorResult = doctor.Result`.
-- Helpers: `DisplayPath` (replaces `$HOME` with `~`), `GetCurrentHostname`, `GetRepoPath`.
+- Helpers: `DisplayPath` (replaces `$HOME` with `~`), `GetCurrentHostname`, `GetRepoPath`, `FormatManagedPath` (formats the display path where a file is/will be stored for a given host).
 
 ## Collaborator responsibilities
 

--- a/docs/context/architecture.md
+++ b/docs/context/architecture.md
@@ -46,6 +46,6 @@ Re-exported from the facade for backwards compatibility:
 
 - One file per subcommand under `cmd/`: `init`, `add`, `rm`, `list`, `status`, `diff`, `push`, `pull`, `doctor`, `bootstrap`.
 - `cmd/root.go` builds the root command, registers persistent flags (`--colors`, `--emoji`, `--no-emoji`, `--quiet`/`-q`), wires `SetGlobalConfig`, and registers all subcommands. Long help text in `Long` is the source of truth for command descriptions.
-- `cmd/output.go` defines `Writer`, `Message`, predefined message constructors (`Success`, `Error`, `Warning`, `Info`, `Target`, `Rocket`, `Sparkles`, `Link`, `Plain`, `Bold`, `Colored`), and the global `OutputConfig`. Auto-detection runs once on first writer access; explicit flags via `SetGlobalConfig` short-circuit it.
+- `cmd/output.go` defines `Writer`, `Message`, predefined message constructors (`Success`, `Error`, `Warning`, `Info`, `Target`, `Rocket`, `Sparkles`, `Link`, `Plain`, `Bold`, `Colored`), and the global `OutputConfig`. Writer exposes `Colors()` and `Quiet()` accessors for commands to query the active color and quiet-mode settings. Auto-detection runs once on first writer access; explicit flags via `SetGlobalConfig` short-circuit it.
 - `cmd.DisplayError` is the single error rendering path; called from `Execute` on any error returned by a `RunE`.
 - `Version` is set from `main.go` at startup via `cmd.SetVersion(version, buildTime)`; both are populated by GoReleaser ldflags.

--- a/docs/context/flows/add-remove.md
+++ b/docs/context/flows/add-remove.md
@@ -26,17 +26,25 @@ Routes to `AddMultiple`, which runs three explicit phases:
 
 - **validatePaths** — for every path: validate, compute abs+relative, reject duplicates against the index, capture stat. Pure read-only; any failure aborts before touching the filesystem.
 - **processFiles** — for each validated file: ensure the destination directory, move into place, create the relative symlink, append to the index, push a rollback action onto a stack. Any failure unwinds the stack via `RollbackAll` (reverse order: delete symlink, remove index entry, move back).
-- **commitFiles** — `git add` every storage path, `git add` the index file, then a single `git.Commit("lnk: added N files")` (or `... recursively`). On any failure, `RollbackAll` plus an error.
+- **commitFiles** — `git add` every storage path, `git add` the index file, then a single `git.Commit("lnk: added N files")`. On any failure, `RollbackAll` plus an error.
 
 The result is exactly one commit per CLI invocation, even with hundreds of files.
+
+Success output lists up to 5 source files, rendered home-relative (~/dir/file) via `displaySourcePath` to disambiguate files with identical basenames in different directories. If more than 5 files were added, additional files are collapsed into "... and N more files".
 
 ## Recursive add (`lnk add --recursive <dir>...`)
 
 `AddRecursiveWithProgress` walks each path with `filepath.Walk`, collecting regular files and symlinks into a flat list, then forwards to `AddMultiple`. If the total exceeds 10 files (`progressThreshold`) and the caller passes a progress callback, progress is reported per file; otherwise progress is skipped to keep tests deterministic.
 
+Progress updates with carriage-return redraws (format: `⏳ Processing N/Total: file`) are only emitted when output is a terminal (`Writer.IsTerminal()`). In non-TTY contexts (piped output), progress text is omitted entirely.
+
+Success output lists the first 5 files with source paths rendered home-relative (~/dir/file). If more than 5 files were added, remaining files are collapsed into "... and N more files" to keep the listing compact.
+
 ## Dry run (`lnk add --dry-run`)
 
 `PreviewAdd` runs the validation pass only — walking directories iff `recursive` — and returns the list of files that would be added. It uses the same duplicate-check against the index but performs no moves, no symlinks, no Git operations.
+
+Output displays all files using `displaySourcePath`, which renders paths as home-relative (~/dir/file) to disambiguate files with identical basenames in different directories. The dry-run preview is not truncated; all matched files are shown for full verification before committing changes.
 
 ## Remove (`lnk rm <file>`)
 

--- a/docs/context/flows/add-remove.md
+++ b/docs/context/flows/add-remove.md
@@ -59,6 +59,8 @@ Output displays all files using `displaySourcePath`, which renders paths as home
 7. `git.Add(<index file>)`, `git.Commit("lnk: removed <basename>")`.
 8. `fs.Move(target, absPath, info)` — restore the original file or directory in place of the symlink.
 
+Output displays the removal summary with path formatting and confirms the original file was restored. When `--host` is set, the host name is included in the success message.
+
 ## Force remove (`lnk rm --force <file>`)
 
-`RemoveForce` is for cases where the symlink is already gone or pointing nowhere useful. It skips the symlink validation, best-effort-removes the symlink, removes the index entry, best-effort `git rm --cached`, commits `lnk: force removed <basename>`, then deletes the storage copy under the repo path with `os.RemoveAll`. There is no original file to restore in this path.
+`RemoveForce` is for cases where the symlink is already gone or pointing nowhere useful. It skips the symlink validation, best-effort-removes the symlink, removes the index entry, best-effort `git rm --cached`, commits `lnk: force removed <basename>`, then deletes the storage copy under the repo path with `os.RemoveAll`. There is no original file to restore in this path. Output explicitly states "Tracking cleanup only — no file was restored to your home directory" so the user understands the asymmetry. When `--host` is set, the host name is included in the message.

--- a/docs/context/flows/doctor.md
+++ b/docs/context/flows/doctor.md
@@ -21,10 +21,11 @@
 type Result struct {
     InvalidEntries []string
     BrokenSymlinks []string
+    BackedUp       []string  // only populated by Fix, not Preview
 }
 ```
 
-`HasIssues()` and `TotalIssues()` are convenience helpers used by the CLI for messaging.
+`HasIssues()` and `TotalIssues()` are convenience helpers used by the CLI for messaging. `BackedUp` tracks managed items whose pre-existing real files were renamed to `.lnk-backup` during symlink restoration.
 
 ## Preview (`lnk doctor --dry-run`)
 
@@ -39,7 +40,7 @@ type Result struct {
 3. If any broken symlinks were found, call `syncer.RestoreSymlinks()`. This is the same code path used by `lnk pull` and includes the `.lnk-backup` rename safety net for pre-existing real files.
 4. If any invalid entries were found, rewrite the index without them, `git add` the index file, and commit with `lnk: cleaned N invalid entry|entries` (singular/plural picked by count).
 
-The CLI then renders parallel "Fixed N issues" / "Restored N broken symlinks" / "Removed N invalid entries" sections and suggests `lnk push` to sync the cleanup commit to the remote.
+The CLI then renders sections for fixed broken symlinks (including any backup notice for files renamed to `.lnk-backup`), removed invalid entries, and a summary of all fixes applied. It suggests `lnk push` to sync the cleanup commit to the remote.
 
 ## Notes on scope
 

--- a/docs/context/flows/init.md
+++ b/docs/context/flows/init.md
@@ -20,7 +20,10 @@ The user lands with an empty Git repo at the repo path and is prompted to `lnk a
    - `git clone <url> <repoPath>` from the parent directory (5-minute timeout).
    - Set upstream: try `branch --set-upstream-to=origin/main main`, else `origin/master master`, else best-effort `origin/HEAD`.
 3. Unless `--no-bootstrap`, `bootstrapper.FindScript()` looks for `bootstrap.sh` at the repo root and runs it via `bash bootstrap.sh` with the user's stdio. A bootstrap failure is reported but does not undo the clone — the user is told to retry with `lnk bootstrap`.
-4. The CLI prints next-step hints: `lnk pull` to restore symlinks, `lnk add <file>` to start managing files.
+4. The CLI prints next-step hints:
+   - `lnk pull` to restore common symlinks.
+   - `lnk pull --host <host>` for each discovered host (enumerated via `findHostConfigs` by listing `.lnk.*` files).
+   - `lnk add <file>` to start managing new files.
 
 ## Adopting an existing remote on a fresh repo
 

--- a/docs/context/flows/sync.md
+++ b/docs/context/flows/sync.md
@@ -16,7 +16,7 @@ All sync operations require the repo path to be a Git repository; otherwise they
 
 ## Diff (`lnk diff`)
 
-`syncer.Diff(color)` runs `git diff --color=never|always` in the repo path. The CLI auto-detects color via `isTerminal()` and prints the raw diff to stdout. When the diff is empty, the CLI prints a structured "No uncommitted changes" message instead.
+`syncer.Diff(color)` runs `git diff --color=never|always` in the repo path. The CLI respects the `--colors` flag (auto-detected or explicit) and routes output through `Writer`. When `--quiet` is set, the command suppresses all output through `Writer`, returning only the exit code. When the diff is empty, the CLI prints a structured "No uncommitted changes" message instead (unless `--quiet` suppresses it).
 
 ## Push (`lnk push [message]`)
 

--- a/docs/context/flows/sync.md
+++ b/docs/context/flows/sync.md
@@ -12,7 +12,7 @@ All sync operations require the repo path to be a Git repository; otherwise they
 4. Counts ahead via `rev-list --count <upstream>..HEAD` (falls back to all-local-commits if the upstream branch doesn't exist remotely).
 5. Counts behind via `rev-list --count HEAD..<upstream>`. Behind is always 0 when there is no upstream.
 
-`StatusInfo{Ahead, Behind, Remote, Dirty}` is then rendered by three branches in `cmd/status.go`: dirty, up-to-date, or ahead/behind.
+`StatusInfo{Ahead, Behind, Remote, Dirty}` is then rendered by three branches in `cmd/status.go`: dirty, up-to-date, or ahead/behind. When dirty, the status display references the actual repo path (via `lnk.DisplayPath(lnk.GetRepoPath())`) and suggests running git operations within it, so messages adapt when the repo is in a custom location via `LNK_HOME` or `XDG_CONFIG_HOME`.
 
 ## Diff (`lnk diff`)
 

--- a/docs/context/flows/sync.md
+++ b/docs/context/flows/sync.md
@@ -45,7 +45,7 @@ The CLI separates the two outcomes (`Restored N symlinks: ...` vs. `All symlinks
 
 - Default — common configuration only.
 - `--host H` — that single host.
-- `--all` — common, then every host found by enumerating `.lnk.*` files at the repo root, each rendered as its own section.
+- `--all` — common, then every host found by enumerating `.lnk.*` files at the repo root, each rendered as its own section. For each host section, the CLI emits a `lnk pull --host <host>` hint to guide restoration.
 
 `lnk list` requires a Git repo at the repo path (same `ErrNotInitialized` check). The list does not verify that managed items still exist or that their symlinks are healthy — that's the job of `lnk doctor`.
 

--- a/docs/context/flows/sync.md
+++ b/docs/context/flows/sync.md
@@ -6,13 +6,13 @@ All sync operations require the repo path to be a Git repository; otherwise they
 
 `syncer.Status` calls `git.GetStatus`, which:
 
-1. Confirms a remote exists (`origin`, or any remote if `origin` is missing) — else `ErrNoRemote`.
+1. Checks if a remote exists (`origin`, or any remote if `origin` is missing). If no remote, `Remote` is set to empty string.
 2. Detects dirty state via `git status --porcelain`.
 3. Resolves the upstream tracking branch via `rev-parse --abbrev-ref --symbolic-full-name @{u}`. If no upstream is set, defaults to `origin/main`.
 4. Counts ahead via `rev-list --count <upstream>..HEAD` (falls back to all-local-commits if the upstream branch doesn't exist remotely).
 5. Counts behind via `rev-list --count HEAD..<upstream>`. Behind is always 0 when there is no upstream.
 
-`StatusInfo{Ahead, Behind, Remote, Dirty}` is then rendered by three branches in `cmd/status.go`: dirty, up-to-date, or ahead/behind. When dirty, the status display references the actual repo path (via `lnk.DisplayPath(lnk.GetRepoPath())`) and suggests running git operations within it, so messages adapt when the repo is in a custom location via `LNK_HOME` or `XDG_CONFIG_HOME`.
+`StatusInfo{Ahead, Behind, Remote, Dirty}` is rendered by `cmd/status.go` through four branches: no remote (guides user to add a remote, shows local state), dirty (suggests commit or push), up-to-date (synced), or ahead/behind (suggests push/pull). When dirty or a remote exists, the display references the actual repo path (via `lnk.DisplayPath(lnk.GetRepoPath())`) so messages adapt when the repo is in a custom location via `LNK_HOME` or `XDG_CONFIG_HOME`.
 
 ## Diff (`lnk diff`)
 
@@ -28,16 +28,15 @@ If there are no changes, push proceeds straight to `git push -u origin`. The CLI
 ## Pull (`lnk pull [--host H]`)
 
 1. `git pull origin` (5-minute timeout).
-2. `RestoreSymlinks` walks the index for the active scope (common or host) and ensures `~/<relativePath>` is a symlink to the stored file:
+2. `RestoreSymlinks` walks the index for the active scope (common or host) and ensures `~/<relativePath>` is a symlink to the stored file, returning `RestoreInfo{Restored, BackedUp}`:
    - Skip entries whose stored file doesn't exist (a partial pull, host not present in repo, etc.).
    - Skip entries whose symlink already resolves to the expected target (`IsValidSymlink` compares absolute paths after resolving relative targets against the link's directory).
    - `os.MkdirAll` the symlink's parent directory.
-   - If `~/<relativePath>` exists and is a regular file or directory, rename it to `<path>.lnk-backup` (do not delete user data).
+   - If `~/<relativePath>` exists and is a regular file or directory, rename it to `<path>.lnk-backup` (preserve user data, append relative path to `BackedUp` list).
    - If it exists and is a stale symlink, `os.Remove` it.
-   - `fs.CreateSymlink(repoItem, symlinkPath)` — relative symlink.
-   - Append the relative path to the `restored` list returned to the CLI.
+   - `fs.CreateSymlink(repoItem, symlinkPath)` — relative symlink, append relative path to `Restored` list.
 
-The CLI separates the two outcomes (`Restored N symlinks: ...` vs. `All symlinks already in place`) and, when `--host` is set, includes the host name in the message.
+The CLI separates outcomes: if `Restored` is non-empty, display the list of restored symlinks and any backup notice (files renamed to .lnk-backup), else display `All symlinks already in place`. When `--host` is set, the host name is included in messaging.
 
 ## List (`lnk list [--host H | --all]`)
 

--- a/docs/context/practices.md
+++ b/docs/context/practices.md
@@ -17,6 +17,11 @@ Conventions and invariants that are enforced by code or test, not aspirational s
 - `--quiet`/`-q` suppresses all `Writer` output; the only signal is the exit code.
 - Auto-detection of TTY happens once on first use; explicit flags pin the config and skip detection.
 
+## Path display
+
+- All paths shown in CLI output that represent where files are stored use `lnk.FormatManagedPath(host, originalPath)` to ensure consistent formatting across commands.
+- `FormatManagedPath` computes the canonical storage location (accounting for host scoping), then displays it home-relative (with `~`) or `/`-stripped for paths outside `$HOME`.
+
 ## Repo-path resolution
 
 - Order is fixed: `LNK_HOME` env > `XDG_CONFIG_HOME/lnk` > `~/.config/lnk`. If the home directory is unavailable, the path falls back to `./lnk`.

--- a/docs/context/practices.md
+++ b/docs/context/practices.md
@@ -16,11 +16,13 @@ Conventions and invariants that are enforced by code or test, not aspirational s
 - `--emoji` and `--no-emoji` are mutually exclusive (enforced via Cobra `MarkFlagsMutuallyExclusive`).
 - `--quiet`/`-q` suppresses all `Writer` output; the only signal is the exit code.
 - Auto-detection of TTY happens once on first use; explicit flags pin the config and skip detection.
+- Progress updates with carriage-return redraws only appear when output is a terminal (`Writer.IsTerminal()`). In piped or redirected contexts, progress text is omitted entirely to prevent log corruption.
 
 ## Path display
 
-- All paths shown in CLI output that represent where files are stored use `lnk.FormatManagedPath(host, originalPath)` to ensure consistent formatting across commands.
-- `FormatManagedPath` computes the canonical storage location (accounting for host scoping), then displays it home-relative (with `~`) or `/`-stripped for paths outside `$HOME`.
+- **Storage paths** shown in CLI output use `lnk.FormatManagedPath(host, originalPath)` to ensure consistent formatting across commands. `FormatManagedPath` computes the canonical storage location (accounting for host scoping), then displays it home-relative (with `~`) or `/`-stripped for paths outside `$HOME`.
+- **Source paths** in preview and batch output use `displaySourcePath` to render home-relative paths (~/dir/file), allowing files with identical basenames in different directories to remain disambiguated. Falls back to the original input on path resolution failure.
+- When listing many files in batch output, only the first 5 entries are shown in detail, followed by "... and N more files" to keep output compact and readable.
 
 ## Repo-path resolution
 

--- a/docs/context/repo-layout.md
+++ b/docs/context/repo-layout.md
@@ -48,7 +48,7 @@ The index file is staged as `.lnk` or `.lnk.<host>`.
 ## Hostname discovery
 
 - `lnk.GetCurrentHostname()` returns `os.Hostname()`. The CLI does not call this implicitly — `--host` is always opaque user input. Users typically run `lnk pull --host $(hostname)` after `lnk pull` on a fresh machine.
-- `cmd.findHostConfigs` enumerates hosts by listing `.lnk.*` files at the repo root (used by `lnk list --all`).
+- `cmd.findHostConfigs` enumerates hosts by listing `.lnk.*` files at the repo root (used by `lnk list --all` and `lnk init -r` for host-specific next-step hints).
 
 ## Repo-detection rules
 

--- a/docs/context/summary.md
+++ b/docs/context/summary.md
@@ -31,9 +31,9 @@ A single error type (`lnkerror.Error`) wraps sentinel errors with optional path 
 - Add files or directories, individually or recursively, with dry-run preview.
 - Per-host configurations via `--host` (mutually exclusive index + storage namespace).
 - Bootstrap script (`bootstrap.sh`) discovery and execution on clone or on demand.
-- Sync status (ahead/behind/dirty), uncommitted diff, commit and push, pull and re-link.
+- Sync status (ahead/behind/dirty/no-remote), uncommitted diff, commit and push, pull and re-link. Handles repositories with no remote configured by showing local state and guiding the user to add a remote.
 - Health checks: detect and repair broken symlinks and stale index entries.
-- Backs up pre-existing real files at symlink destinations to `<path>.lnk-backup` instead of overwriting on `pull`.
+- Backs up pre-existing real files at symlink destinations to `<path>.lnk-backup` instead of overwriting on `pull`. Reports both restored symlinks and backed-up files separately.
 - Output controls: `--colors auto|always|never`, `--emoji` / `--no-emoji`, `--quiet`/`-q`, plus `NO_COLOR` env.
 
 ## Tech Stack

--- a/docs/context/terminology.md
+++ b/docs/context/terminology.md
@@ -15,3 +15,5 @@
 - **ahead / behind** — local commits not yet on the upstream tracking branch / upstream commits not yet local.
 - **invalid entry** — a path listed in `.lnk`/`.lnk.<host>` that no longer corresponds to a stored file in the repo, or that escapes the storage path (`..` or absolute). Cleaned by `lnk doctor`.
 - **broken symlink** — a managed item that exists in storage but whose `~/<relative path>` is not a symlink pointing at the stored file. Repaired by `lnk doctor` and by `lnk pull`.
+- **`.lnk-backup` file** — file or directory renamed from `~/<relative path>` when `lnk pull` finds a regular file/directory where a symlink should exist. Preserves user data instead of overwriting.
+- **RestoreInfo** — return type of `Pull()` and `RestoreSymlinks()`. Contains two lists: `Restored` (relative paths where symlinks were created) and `BackedUp` (relative paths where pre-existing files were renamed to `.lnk-backup`).

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -14,9 +14,13 @@ import (
 )
 
 // Result contains the results of a doctor scan or execution.
+// BackedUp is populated only by Fix (not Preview): it lists managed items
+// whose pre-existing real files were renamed to <path>.lnk-backup during
+// the symlink restoration step.
 type Result struct {
 	InvalidEntries []string
 	BrokenSymlinks []string
+	BackedUp       []string
 }
 
 // HasIssues returns true if any issues were found.
@@ -85,9 +89,11 @@ func (d *Checker) Fix() (*Result, error) {
 
 	// Fix broken symlinks via the syncer's RestoreSymlinks.
 	if len(result.BrokenSymlinks) > 0 {
-		if _, err := d.syncer.RestoreSymlinks(); err != nil {
+		restoreInfo, err := d.syncer.RestoreSymlinks()
+		if err != nil {
 			return nil, fmt.Errorf("failed to restore symlinks: %w", err)
 		}
+		result.BackedUp = restoreInfo.BackedUp
 	}
 
 	// Remove invalid entries from .lnk file.

--- a/internal/filemanager/filemanager.go
+++ b/internal/filemanager/filemanager.go
@@ -199,7 +199,7 @@ func (fm *Manager) processFiles(files []validatedFile, progress ProgressCallback
 
 	for i, f := range files {
 		if progress != nil {
-			progress(i+1, total, filepath.Base(f.absPath))
+			progress(i+1, total, f.relativePath)
 		}
 
 		storagePath := fm.tracker.HostStoragePath()

--- a/internal/filemanager/filemanager.go
+++ b/internal/filemanager/filemanager.go
@@ -362,7 +362,7 @@ func (fm *Manager) PreviewAdd(paths []string, recursive bool) ([]string, error) 
 			return nil, fmt.Errorf("failed to get managed items: %w", err)
 		}
 		if slices.Contains(managedItems, relativePath) {
-			return nil, fmt.Errorf("\u274c File is already managed by lnk: \033[31m%s\033[0m", relativePath)
+			return nil, lnkerror.WithPath(lnkerror.ErrAlreadyManaged, relativePath)
 		}
 
 		validFiles = append(validFiles, filePath)

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -377,18 +378,28 @@ type StatusInfo struct {
 	Dirty  bool
 }
 
-// GetStatus returns the repository status relative to remote
+// GetStatus returns the repository status relative to remote.
+// When no remote is configured, returns a StatusInfo with Remote="" and
+// Behind=0; Ahead reflects the number of local commits and Dirty reflects
+// the working tree state, so callers can still report useful local state.
 func (g *Git) GetStatus() (*StatusInfo, error) {
-	// Check if we have a remote
-	_, err := g.GetRemoteInfo()
-	if err != nil {
-		return nil, err
-	}
-
 	// Check for uncommitted changes
 	dirty, err := g.HasChanges()
 	if err != nil {
 		return nil, lnkerror.WithSuggestion(ErrUncommitted, "verify your git repository is valid")
+	}
+
+	// Check if we have a remote — if not, fall back to local-only status.
+	if _, err := g.GetRemoteInfo(); err != nil {
+		if errors.Is(err, ErrNoRemote) {
+			return &StatusInfo{
+				Ahead:  g.getLocalCommitCount(),
+				Behind: 0,
+				Remote: "",
+				Dirty:  dirty,
+			}, nil
+		}
+		return nil, err
 	}
 
 	// Get the remote tracking branch
@@ -417,6 +428,25 @@ func (g *Git) GetStatus() (*StatusInfo, error) {
 		Remote: remoteBranch,
 		Dirty:  dirty,
 	}, nil
+}
+
+// getLocalCommitCount returns the total number of commits on HEAD, or 0 if
+// there are no commits yet (fresh repo).
+func (g *Git) getLocalCommitCount() int {
+	cmd := g.execGitCommand(shortTimeout, "rev-list", "--count", "HEAD")
+	output, err := cmd.Output()
+	if err != nil {
+		return 0
+	}
+	count := strings.TrimSpace(string(output))
+	if count == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(count)
+	if err != nil {
+		return 0
+	}
+	return n
 }
 
 // getAheadCount returns how many commits ahead of remote

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -537,6 +537,25 @@ func (g *Git) Diff(color bool) (string, error) {
 	return string(output), nil
 }
 
+// HasDiff reports whether the working tree has uncommitted diff content,
+// using `git diff --quiet` so the patch is never materialized.
+func (g *Git) HasDiff() (bool, error) {
+	cmd := g.execGitCommand(shortTimeout, "diff", "--quiet")
+
+	err := cmd.Run()
+	if err == nil {
+		return false, nil
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return false, lnkerror.Wrap(ErrGitTimeout)
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+		return true, nil
+	}
+	return false, lnkerror.Wrap(ErrDiff)
+}
+
 // AddAll stages all changes in the repository
 func (g *Git) AddAll() error {
 	cmd := g.execGitCommand(shortTimeout, "add", "-A")

--- a/internal/lnk/lnk.go
+++ b/internal/lnk/lnk.go
@@ -152,6 +152,34 @@ func DisplayPath(path string) string {
 	return path
 }
 
+// storageRootForHost returns the storage root path for the given host.
+// For host=="", returns the repo root. For host!="", returns <repo>/<host>.lnk.
+func storageRootForHost(repoPath, host string) string {
+	if host != "" {
+		return filepath.Join(repoPath, host+".lnk")
+	}
+	return repoPath
+}
+
+// FormatManagedPath returns a display-friendly path to where the file at
+// originalPath is (or will be) stored under lnk management for the given host.
+// host="" selects the common configuration. originalPath may be absolute or
+// relative to the current working directory.
+func FormatManagedPath(host, originalPath string) string {
+	absPath, err := filepath.Abs(originalPath)
+	if err != nil {
+		return originalPath
+	}
+	relativePath, err := fs.GetRelativePath(absPath)
+	if err != nil {
+		return originalPath
+	}
+	repoPath := GetRepoPath()
+	storageRoot := storageRootForHost(repoPath, host)
+	storage := filepath.Join(storageRoot, relativePath)
+	return DisplayPath(storage)
+}
+
 // GetCurrentHostname returns the current system hostname.
 func GetCurrentHostname() (string, error) {
 	hostname, err := os.Hostname()

--- a/internal/lnk/lnk.go
+++ b/internal/lnk/lnk.go
@@ -37,6 +37,10 @@ type ProgressCallback = filemanager.ProgressCallback
 // StatusInfo contains repository sync status information.
 type StatusInfo = syncer.StatusInfo
 
+// RestoreInfo reports symlink restoration results, including which files
+// were renamed to <path>.lnk-backup to preserve user data.
+type RestoreInfo = syncer.RestoreInfo
+
 // DoctorResult contains the results of a doctor scan or execution.
 type DoctorResult = doctor.Result
 
@@ -118,13 +122,13 @@ func (l *Lnk) RemoveForce(filePath string) error { return l.files.RemoveForce(fi
 
 // --- Sync delegates ---
 
-func (l *Lnk) Status() (*StatusInfo, error)       { return l.syncer.Status() }
-func (l *Lnk) Diff(color bool) (string, error)    { return l.syncer.Diff(color) }
-func (l *Lnk) Push(message string) error          { return l.syncer.Push(message) }
-func (l *Lnk) Pull() ([]string, error)            { return l.syncer.Pull() }
-func (l *Lnk) List() ([]string, error)            { return l.syncer.List() }
-func (l *Lnk) GetCommits() ([]string, error)      { return l.syncer.GetCommits() }
-func (l *Lnk) RestoreSymlinks() ([]string, error) { return l.syncer.RestoreSymlinks() }
+func (l *Lnk) Status() (*StatusInfo, error)           { return l.syncer.Status() }
+func (l *Lnk) Diff(color bool) (string, error)        { return l.syncer.Diff(color) }
+func (l *Lnk) Push(message string) error              { return l.syncer.Push(message) }
+func (l *Lnk) Pull() (*RestoreInfo, error)            { return l.syncer.Pull() }
+func (l *Lnk) List() ([]string, error)                { return l.syncer.List() }
+func (l *Lnk) GetCommits() ([]string, error)          { return l.syncer.GetCommits() }
+func (l *Lnk) RestoreSymlinks() (*RestoreInfo, error) { return l.syncer.RestoreSymlinks() }
 
 // --- Bootstrap delegates ---
 

--- a/internal/lnk/lnk.go
+++ b/internal/lnk/lnk.go
@@ -124,6 +124,7 @@ func (l *Lnk) RemoveForce(filePath string) error { return l.files.RemoveForce(fi
 
 func (l *Lnk) Status() (*StatusInfo, error)           { return l.syncer.Status() }
 func (l *Lnk) Diff(color bool) (string, error)        { return l.syncer.Diff(color) }
+func (l *Lnk) HasDiff() (bool, error)                 { return l.syncer.HasDiff() }
 func (l *Lnk) Push(message string) error              { return l.syncer.Push(message) }
 func (l *Lnk) Pull() (*RestoreInfo, error)            { return l.syncer.Pull() }
 func (l *Lnk) List() ([]string, error)                { return l.syncer.List() }

--- a/internal/lnk/lnk_test.go
+++ b/internal/lnk/lnk_test.go
@@ -111,10 +111,11 @@ func (suite *CoreTestSuite) TestErrorConditions() {
 	suite.Error(err)
 	suite.Contains(err.Error(), "File is not managed by lnk")
 
-	// Test status without remote
-	_, err = suite.lnk.Status()
-	suite.Error(err)
-	suite.Contains(err.Error(), "No remote repository is configured")
+	// Status without remote should still succeed and report local state
+	// (Remote="" indicates no remote configured).
+	status, err := suite.lnk.Status()
+	suite.Require().NoError(err)
+	suite.Empty(status.Remote)
 }
 
 // Test hostname detection

--- a/internal/lnk/sync_test.go
+++ b/internal/lnk/sync_test.go
@@ -37,8 +37,9 @@ func (suite *CoreTestSuite) TestSymlinkRestoration() {
 	suite.Require().NoError(err)
 
 	// Should have restored the symlink
-	suite.Len(restored, 1)
-	suite.Equal(".bashrc", restored[0])
+	suite.Len(restored.Restored, 1)
+	suite.Equal(".bashrc", restored.Restored[0])
+	suite.Empty(restored.BackedUp)
 
 	// Check that file is now a symlink
 	info, err := os.Lstat(targetFile)
@@ -301,8 +302,8 @@ func (suite *CoreTestSuite) TestMultihostSymlinkRestoration() {
 	suite.Require().NoError(err)
 
 	// Should have restored the symlink
-	suite.Len(restored, 1)
-	suite.Equal(".bashrc", restored[0])
+	suite.Len(restored.Restored, 1)
+	suite.Equal(".bashrc", restored.Restored[0])
 
 	// Check that file is now a symlink
 	info, err := os.Lstat(targetFile)
@@ -559,7 +560,8 @@ func (suite *CoreTestSuite) TestRestoreSymlinksBackupsExistingFile() {
 	// Restore symlinks — should back up the existing file
 	restored, err := suite.lnk.RestoreSymlinks()
 	suite.Require().NoError(err)
-	suite.Len(restored, 1)
+	suite.Len(restored.Restored, 1)
+	suite.Equal([]string{".bashrc"}, restored.BackedUp)
 
 	// Target should now be a symlink
 	info, err := os.Lstat(targetFile)

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -13,11 +13,19 @@ import (
 )
 
 // StatusInfo contains repository sync status information.
+// Remote is empty when no remote is configured; in that case Behind is always 0.
 type StatusInfo struct {
 	Ahead  int
 	Behind int
 	Remote string
 	Dirty  bool
+}
+
+// RestoreInfo reports which managed items had symlinks restored and which
+// pre-existing real files were renamed to <path>.lnk-backup along the way.
+type RestoreInfo struct {
+	Restored []string
+	BackedUp []string
 }
 
 // Syncer handles synchronization operations.
@@ -93,7 +101,7 @@ func (s *Syncer) Push(message string) error {
 }
 
 // Pull fetches changes from remote and restores symlinks as needed.
-func (s *Syncer) Pull() ([]string, error) {
+func (s *Syncer) Pull() (*RestoreInfo, error) {
 	if !s.git.IsGitRepository() {
 		return nil, lnkerror.WithSuggestion(lnkerror.ErrNotInitialized, "run 'lnk init' first")
 	}
@@ -102,12 +110,12 @@ func (s *Syncer) Pull() ([]string, error) {
 		return nil, err
 	}
 
-	restored, err := s.RestoreSymlinks()
+	info, err := s.RestoreSymlinks()
 	if err != nil {
 		return nil, fmt.Errorf("failed to restore symlinks: %w", err)
 	}
 
-	return restored, nil
+	return info, nil
 }
 
 // List returns the list of files and directories currently managed by lnk.
@@ -130,8 +138,10 @@ func (s *Syncer) GetCommits() ([]string, error) {
 }
 
 // RestoreSymlinks finds all managed items and ensures they have proper symlinks.
-func (s *Syncer) RestoreSymlinks() ([]string, error) {
-	var restored []string
+// Reports both which items had a symlink (re)created and which pre-existing
+// real files were renamed to <path>.lnk-backup along the way.
+func (s *Syncer) RestoreSymlinks() (*RestoreInfo, error) {
+	info := &RestoreInfo{}
 
 	managedItems, err := s.tracker.GetManagedItems()
 	if err != nil {
@@ -162,13 +172,14 @@ func (s *Syncer) RestoreSymlinks() ([]string, error) {
 			return nil, fmt.Errorf("failed to create directory %s: %w", symlinkDir, err)
 		}
 
-		if info, err := os.Lstat(symlinkPath); err == nil {
-			if info.Mode()&os.ModeSymlink == 0 {
+		if existing, err := os.Lstat(symlinkPath); err == nil {
+			if existing.Mode()&os.ModeSymlink == 0 {
 				// Existing item is a regular file or directory — back it up
 				backupPath := symlinkPath + ".lnk-backup"
 				if err := os.Rename(symlinkPath, backupPath); err != nil {
 					return nil, fmt.Errorf("failed to back up existing item %s to %s: %w", symlinkPath, backupPath, err)
 				}
+				info.BackedUp = append(info.BackedUp, relativePath)
 			} else {
 				// Existing item is a stale symlink — safe to remove
 				if err := os.Remove(symlinkPath); err != nil {
@@ -181,10 +192,10 @@ func (s *Syncer) RestoreSymlinks() ([]string, error) {
 			return nil, err
 		}
 
-		restored = append(restored, relativePath)
+		info.Restored = append(info.Restored, relativePath)
 	}
 
-	return restored, nil
+	return info, nil
 }
 
 // IsValidSymlink checks if the given path is a symlink pointing to the expected target.

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -76,6 +76,16 @@ func (s *Syncer) Diff(color bool) (string, error) {
 	return s.git.Diff(color)
 }
 
+// HasDiff reports whether the working tree has uncommitted diff content
+// without materializing the patch.
+func (s *Syncer) HasDiff() (bool, error) {
+	if !s.git.IsGitRepository() {
+		return false, lnkerror.WithSuggestion(lnkerror.ErrNotInitialized, "run 'lnk init' first")
+	}
+
+	return s.git.HasDiff()
+}
+
 // Push stages all changes and creates a sync commit, then pushes to remote.
 func (s *Syncer) Push(message string) error {
 	if !s.git.IsGitRepository() {


### PR DESCRIPTION
### Why
CLI output was inconsistent across flags and error paths, and host-specific
workflows lacked clear guidance. This adds output control, sharpens the
--quiet contract for automation, and makes host guidance more discoverable.

### What
- Add global --colors and --quiet options to control output formatting
- Make --quiet suppress bootstrap script output (both `lnk bootstrap` and
  the auto-bootstrap path in `lnk init -r`), not just framing messages
- Make `lnk diff --quiet` exit 0 when clean and 1 when dirty, without
  materializing the patch — usable as a CI/script "is the repo dirty?" check
- Add per-host pull hints to init and list commands for workflow discovery
- Fix edge cases in status, pull, and rm commands including no-remote handling
- Improve output for file backups and restoration workflows

### How to verify
- Run commands with --colors and --quiet; verify output respects flags
- In a repo with a `bootstrap.sh` that prints, run `lnk --quiet bootstrap`
  and `lnk --quiet init -r <repo>`; confirm no script output leaks
- Run `lnk diff --quiet` on a clean repo (`echo $?` → 0) and on a dirty
  repo (`echo $?` → 1); confirm no stdout/stderr in either case
- Run init -r clone and list --all; confirm host-specific pull hints appear
- Run status on a repository without a remote; verify informative output
- Run pull with file conflicts; verify backup notices are displayed
- Run test suite and verify all output scenarios are covered